### PR TITLE
fix(config): opt darwin evaluator into --sandbox mock

### DIFF
--- a/dream.config.json
+++ b/dream.config.json
@@ -52,7 +52,7 @@
   },
   "evaluatorEntrypoints": {
     "bench": "npm test",
-    "darwin": "npx @metaharness/darwin evolve"
+    "darwin": "npx @metaharness/darwin evolve --sandbox mock"
   },
   "adrConvention": "4-digit",
   "competitors": [


### PR DESCRIPTION
## Summary
- `dream.config.json`'s darwin evaluator entrypoint used `npx @metaharness/darwin evolve` with no `--sandbox` flag, which defaults to `real` mode.
- `real` mode is documented in darwin's own source (`mock-sandbox.js`, `evolve.js`) as structurally unable to discriminate between variants: it scores each variant by running the *target repo's* test command, which never imports darwin's synthetic 7-surface harness. Every variant gets the identical deterministic score (0.985, derived from darwin's own `scorer.js` formula: taskSuccess=1, testPassRate=1, traceQuality=0.9, cost/latency/safety pinned to 1.0) — no selection pressure exists.
- `mock` sandbox mode (darwin ADR-102, the shipped fix for this exact defect) scores each variant as a pure function of the mutated surface's extracted parameters, so a real mutation genuinely changes the outcome. One-line config change to opt in.

Full writeup with the source-level verification: #12

## Test plan
- [x] `npm run build` — clean across all 6 packages
- [x] `npm test` — 96/96 passing (unaffected; this is a runtime evaluator command string, not exercised by the current test suite)
- [x] Confirmed the `--sandbox` flag and its `real` default against the actually-published `@metaharness/darwin@0.9.1` (`npm view`/`npm pack`), not just a stale cached copy