### PR TITLE
evaluation-adapters: auto-wire evaluatorEntrypoints via execFile, not shell

### DIFF
--- a/docs/adrs/ADR-0003-dream-cycle-evaluation-adapters-config-sourced-execfile.md
+++ b/docs/adrs/ADR-0003-dream-cycle-evaluation-adapters-config-sourced-execfile.md
@@ -1,0 +1,120 @@
+# ADR-0003: Config-sourced evaluator entrypoints must execute via `execFile` (argv array), never a shell
+
+- **Status**: Proposed
+- **Date**: 2026-08-17
+- **Related**: ADR-0002 (defines `classifyEntrypointResult`; §2/§3 explicitly deferred auto-wiring `evaluatorEntrypoints` and named the shell-injection precondition for doing so safely)
+- **Deciders**: dream-cycle nightly session (evaluation-adapters, SCAN=flywheel/darwin), 2026-08-17
+- **Tags**: dream-cycle, evaluation-adapters, security, evaluator-trust, witness-every-quantitative-claim
+
+## 1. Context
+
+ADR-0002 (2026-08-13) shipped `classifyEntrypointResult` and a manual
+`verify-entrypoint <label> --cmd "<command>"` command, but explicitly deferred
+auto-wiring `dream.config.json#evaluatorEntrypoints` through it — issue #6's
+Reward-Hack Check flagged the reason: `IO.exec` runs via `child_process.exec`
+(`/bin/sh -c`), safe only because `cmd` came from a human-typed CLI flag. The
+"natural next automation" (issue #6's words) — feeding config-sourced values
+into that same exec path — would pipe a repo-modifiable string into an
+unsanitized shell, a CWE-78 command-injection shape, and issue #6 said this
+"MUST be addressed (allowlist or `execFile` with argv array) before anyone
+wires that automation."
+
+Tonight is that automation: `verify-entrypoints [config]` reads
+`evaluatorEntrypoints` directly from a dream.config and runs every configured
+command without a human retyping it. This ADR records the precondition ADR-0002
+deferred, now that it's actually being built.
+
+## 2. Decision
+
+Config-sourced evaluator-entrypoint commands are tokenized into an argv array
+(`tokenizeCommand`, `packages/cli/src/entrypoint.ts`) and executed via
+`child_process.execFile` (`IO.execFile`, wired in `bin.ts`) — never
+`child_process.exec`. `execFile` does not spawn `/bin/sh`; the tokenized argv
+is passed straight to the target binary, so shell metacharacters in a config
+value (`&&`, `;`, `` $() ``, `|`) are received as literal argument text, not
+executable syntax.
+
+This is a repo-wide invariant going forward, not just this command's
+implementation detail: **any future code path that runs a command sourced from
+a config file, ledger row, or other non-human-typed input must use
+`IO.execFile`, never `IO.exec`.** The existing manual `verify-entrypoint --cmd`
+command is the one carved-out exception — its input is a human-typed local CLI
+flag, the exact case ADR-0002 already assessed as low-risk, and it is left
+unchanged tonight.
+
+## 3. Consequences
+
+- **Closes ADR-0002's deferred precondition.** `evaluatorEntrypoints` can now
+  be auto-wired without reintroducing the injection shape ADR-0002 flagged.
+- **New `IO.execFile?` capability**, optional and additive — `IO.exec?` is
+  untouched, every existing IO/test fake unaffected (confirmed: baseline 96
+  tests → candidate 105, 0 removed/modified).
+- **`tokenizeCommand` is intentionally minimal** (whitespace split +
+  double-quoted segments) — sufficient for this repo's own config values
+  (`npm test`, `npx @metaharness/darwin evolve --sandbox mock`), not a general
+  shell-grammar parser. A config value needing single-quotes or escaping would
+  need the tokenizer extended first; not built preemptively.
+- **Does not sandbox the entrypoint process itself** — `execFile` still runs
+  the real binary with real filesystem/network access, same as `exec` did.
+  This ADR closes the shell-injection layer, not the "should evaluator
+  entrypoints run in a container" question (out of scope; a much larger,
+  protected-path change per `.github/workflows/automerge.yml`'s own guard
+  list, and not what issue #6 asked for).
+
+## 4. Alternatives Considered
+
+- **Allowlist of permitted commands/binaries** (the other option issue #6
+  named). Rejected for tonight: requires deciding and maintaining an allowlist
+  policy (which binaries, which flags) with no current evidence of what that
+  should contain beyond the 2 entrypoints this repo configures today;
+  `execFile` fully closes the injection vector with less new policy surface.
+  Worth revisiting if `evaluatorEntrypoints` grows to include less-trusted
+  sources.
+- **Sanitize/escape the string before passing to `exec`.** Rejected: shell
+  quoting/escaping is a well-known footgun (the exact class of bug this repo's
+  own tests now probe for in `tokenizeCommand`'s metacharacter test) — safer
+  to never construct a shell string at all than to escape one correctly.
+- **Full container sandbox per entrypoint invocation** (OpenHands/SWE-agent's
+  approach, researched tonight — see the committed report's Competitor table).
+  Rejected for tonight: correct long-term direction, but a materially larger
+  change (new infra dependency, protected-path territory) than this candidate's
+  scope; the classifier + execFile pairing is the cheapest correct primitive
+  available at this repo's current scale.
+
+## 5. Test Contract
+
+1. `tokenizeCommand` is pure (no I/O) and unit-tested: plain whitespace
+   commands, double-quoted segments, and — the security-relevant case — shell
+   metacharacters (`&&`, `` $() ``) verified to tokenize as literal argv text,
+   not re-split as shell syntax (`packages/cli/src/entrypoint.test.ts`).
+2. `dream-machine verify-entrypoints` round-trips real `execFile` results
+   through the existing classifier, aggregates to the worst verdict's exit
+   code, and reports a clean no-op when a config has no
+   `evaluatorEntrypoints` (`packages/cli/src/index.test.ts`).
+3. Live receipt against this repo's real `dream.config.json` tonight: `bench`
+   → live, `darwin` → live — matches hand-verified ground truth.
+4. Live injection-safety receipt (not a unit test, an actual subprocess run):
+   a config value `"npm test && rm -rf /"` / `"echo hi && touch PWNED"`
+   produces no shell side effect — `&&` arrives as literal argv text to a
+   single process, confirmed by absence of the marker file. Full transcript in
+   `docs/dream-cycle/2026-08-17-evaluation-adapters-report.md`.
+5. No pre-existing test weakened, removed, or modified; `npm test` baseline
+   96/96 → candidate 105/105, 0 regressions.
+
+## 6. References
+
+- ADR-0002 §2, §3 (the deferred precondition this ADR closes).
+- Issue #6 (2026-08-13), Reward-Hack Check section — the original flag.
+- CWE-78 (OS Command Injection) mitigation guidance: `execFile`/`spawn` with
+  an argv array vs `exec`'s shell string — cross-checked tonight across
+  SecureFlag's Node.js OS-command-injection reference, nodejs-security.com's
+  secure-coding guide, and the ESLint `eslint-plugin-security`
+  `detect-child-process` rule docs (Grade B, cross-checked, non-fabricated).
+- NVIDIA Developer Blog, "Practical Security Guidance for Sandboxing Agentic
+  Workflows and Managing Execution Risk" (2026) — cross-repo context on where
+  comparable agent frameworks (OpenHands) do and don't apply sandboxing to
+  config/hook-driven process execution (Grade B, vendor technical blog,
+  cross-checked against the framework's own architecture docs).
+- DSPy/GEPA official docs (`dspy.ai`) — comparison point: in-process metric
+  functions have no analogous shell surface at all (Grade A, official docs,
+  fetched directly).

--- a/docs/adrs/INDEX.md
+++ b/docs/adrs/INDEX.md
@@ -9,6 +9,7 @@ Alternatives Considered → Test Contract → References.
 |-----|-------|--------|
 | [ADR-0001](./ADR-0001-dream-machine-engine.md) | The Dream Machine engine — a config-driven, evidence-gated nightly evolution loop composed from the ruvnet stack | Accepted (v0.1.0 shipped) |
 | [ADR-0002](./ADR-0002-dream-cycle-security-adversarial-entrypoint-liveness.md) | Evaluator entrypoints must be classified live/blocked/suspicious-silent before an EVALUATED verdict is recorded | Proposed |
+| [ADR-0003](./ADR-0003-dream-cycle-evaluation-adapters-config-sourced-execfile.md) | Config-sourced evaluator entrypoints must execute via `execFile` (argv array), never a shell | Proposed |
 
 ## How to amend
 

--- a/docs/dream-cycle/2026-08-17-evaluation-adapters-report.md
+++ b/docs/dream-cycle/2026-08-17-evaluation-adapters-report.md
@@ -1,0 +1,107 @@
+# Evaluation-Adapters SOTA Report — 2026
+
+**Repo**: `ruvnet/dream-machine` · **Night**: 2026-08-17 · **Rotation**: slot 2 (DAYINT % 5) → DEEP=`evaluation-adapters`, SCAN=`flywheel,darwin`. No bonus modulus (DAYINT % 25 = 17, % 75 = 17).
+
+## TL;DR
+
+Closed a real, previously-flagged security gap: `dream.config.json#evaluatorEntrypoints` (`bench`, `darwin`) was documentation only — a human had to manually retype each command into `verify-entrypoint --cmd "..."` to get a liveness classification. 2026-08-13's session (issue #6, ADR-0002) recommended auto-wiring the config through the classifier but explicitly deferred it, flagging that piping a config-sourced string into `child_process.exec` (a shell) first would be a real injection vector. Tonight ships that deferred work safely: a new `verify-entrypoints [config]` command tokenizes each configured command into an argv array and runs it via `execFile` (no shell), so shell metacharacters in a config value (`&&`, `$()`, `;`) become inert literal arguments instead of executable syntax. +170/−3 lines, 5 files, one conceptual change.
+
+## What's new
+
+- `tokenizeCommand()` (`packages/cli/src/entrypoint.ts`) — pure argv tokenizer (whitespace split + double-quote segments).
+- `IO.execFile?(argv: string[])` — new optional IO capability, alongside the existing `IO.exec?(cmd: string)`.
+- `dream-machine verify-entrypoints [config]` — reads `evaluatorEntrypoints` from a dream.config, tokenizes + `execFile`s each configured command, classifies via the existing (2026-08-13) `classifyEntrypointResult`, prints one line per entrypoint, exits with the worst verdict's code (0 live / 1 blocked / 2 suspicious-silent).
+- `bin.ts` wires `execFile` via Node's `child_process.execFile` (promisified) — genuinely shell-free, not exec-with-escaping.
+- The existing manual `verify-entrypoint --cmd` command (human-typed, shell-based) is untouched — the risk it carries was already assessed as acceptable in ADR-0002 (trusted local CLI flag, no config-sourced input) and stays that way.
+
+## Competitor comparison (how other agent/eval harnesses execute config/tool commands)
+
+| System | Execution model for evaluator/tool commands | Shell-injection surface | Grade |
+|---|---|---|---|
+| **OpenHands** | Full Docker container sandbox per session; all bash actions execute inside an isolated runtime reached via a REST `ActionExecutionClient`, not the host shell directly | Sandboxed at the container boundary, but NVIDIA's 2026 review of agentic sandboxing notes many frameworks (OpenHands included, per the review's general finding) only sandbox the *invocation-time* tool call — hooks/MCP-spawned local processes commonly run **outside** the sandbox | B (official docs + cross-checked NVIDIA technical blog) |
+| **SWE-agent** | Shells test/build commands into a Docker container per task; the *container* is the isolation boundary, not command-string hygiene | Same class of host-shell risk this repo just closed, pushed down a layer (still string-built commands, just inside a container) | C (architecture recalled from public docs, not re-verified tonight) |
+| **DSPy / GEPA** | Metric functions are **in-process Python calls** (`metric(gold, pred, trace=...)` → `Prediction(score=...)`), never shelled-out subprocesses | None — sidesteps this entire vulnerability class by not invoking a shell/process at all for scoring | A (official `dspy.ai` docs, fetched directly tonight) |
+| **Sakana AI Scientist** | Runs generated experiment code inside a sandboxed execution environment (Docker-based, per the broader 2026 sandboxing literature for this class of system) | Isolation is container-level; known adjacent research (SandboxEval, RedCode, SandboxEscapeBench) shows container/orchestration misconfiguration remains the live attack surface for this whole system class | B (cross-checked across independent 2026 papers, not this repo's own measurement) |
+| **AutoGPT lineage** | Historically shells tool commands with limited sandboxing by default; ecosystem has moved toward pluggable sandboxed executors | Highest surface of this group when run without an added sandbox layer | C (general/single-source recall) |
+
+**Where this repo sits**: no container sandbox exists for `evaluatorEntrypoints` (out of scope tonight — that's a much larger, protected-path change per `.github/workflows/automerge.yml`'s own guard list). Tonight's fix is the cheapest correct primitive available at this repo's current scale: eliminate the shell layer itself for config-sourced commands, which is exactly the CWE-78 mitigation independently corroborated across multiple secure-coding sources tonight (SecureFlag, nodejs-security.com, ESLint `detect-child-process` rule docs — Grade B, cross-checked, non-fabricated).
+
+## Frozen hypothesis (frozen before implementation, not modified after)
+
+> Given `dream.config.json`'s `evaluatorEntrypoints` (`bench`, `darwin`) are config-only documentation requiring manual retyping into `verify-entrypoint --cmd`, when a new `verify-entrypoints` command reads the config and executes each entrypoint via `execFile` on a tokenized argv (never `exec`/a shell), then (a) every configured entrypoint classifies identically to its hand-verified ground truth with zero manual retyping, and (b) a config value containing shell metacharacters must never be shell-interpreted — subject to: no existing test changes, no change to the `bench: npm test` evaluator's own behavior, and the existing manual `verify-entrypoint` command stays untouched.
+
+## Benchmarks / Evaluation
+
+Real evaluator: `npm test` (vitest, this repo's own `bench` entrypoint). Baseline = parent commit `8ce385786faa5e63cc0e7105cc6e96f663a51f07` (`main`, "fix(config): opt darwin evaluator into `--sandbox mock` (#13)").
+
+| | Baseline (8ce3857) | Candidate |
+|---|---|---|
+| Test files | 7 | 7 |
+| Tests | 96 | 105 (+9, 0 removed, 0 modified) |
+| Result | 96 passed | 105 passed |
+
+`npm run typecheck`: pre-existing failure on **both** baseline and candidate (`tsconfig.json(1,12): TS18002: The 'files' list in config file ... is empty` — root `tsconfig.json` is `{"files":[],"include":[]}`, a references-only stub; `tsc -b` doesn't resolve project references here). Reproduced on baseline via `git stash` before candidate existed — pre-existing, not caused by tonight's candidate, not fixed tonight (out of scope). `npm run lint`: clean on candidate, 0 errors/warnings.
+
+**Live receipt against this repo's real `dream.config.json` tonight:**
+```
+$ node packages/cli/dist/bin.js verify-entrypoints dream.config.json
+bench: live (exit 0) — produced output
+darwin: live (exit 0) — produced output
+EXIT=0
+```
+Matches 2026-08-13's hand-verified ground truth for these two entrypoints exactly (`bench`→live; `darwin`'s command has since been fixed to `evolve --sandbox mock` by commit #13, upgrading it from that night's `blocked` — expected, a config fix landed since, not a regression in tonight's classifier).
+
+**Live injection-safety receipt** (not a unit test — an actual subprocess run, reproducible):
+```
+$ cat evil.config.json
+{"evaluatorEntrypoints":{"bench":"echo hi && touch PWNED"}}
+$ node packages/cli/dist/bin.js verify-entrypoints evil.config.json
+bench: live (exit 0) — produced output
+$ ls PWNED
+no - safe
+```
+`echo` printed `hi && touch PWNED` as **literal stdout** (correctly classified `live` — echo genuinely ran and produced output); no `PWNED` file was created. Had this route through `child_process.exec` (a shell), `&&` would have chained a second command and created the file. This is the concrete failure mode issue #6 flagged as a precondition for auto-wiring; it does not occur.
+
+## Darwin Lineage
+
+`DARWIN=not-applicable`. Ran `npx @metaharness/darwin evolve --sandbox mock` directly tonight as part of control-plane discovery (winner `g2_v5`, `+0.110` over baseline, `safety=1.00` throughout) — confirms the entrypoint itself is genuinely live and produces a real receipt, which is exactly what tonight's `verify-entrypoints darwin` line independently reports. No evolvable population for tonight's own candidate: `tokenizeCommand` is a single pure function with an exhaustive 2-branch grammar (quoted / unquoted token), same shape as 2026-08-13's classifier that also skipped Darwin.
+
+## Evidence
+
+- OBSERVATION: `dream.config.json#evaluatorEntrypoints` had no automatic wiring; `verify-entrypoint` required a human to copy the command string by hand (grade A, direct code read, `packages/cli/src/index.ts` pre-candidate).
+- OBSERVATION: issue #6 (2026-08-13) explicitly named this as deferred follow-up work with an explicit precondition ("MUST be addressed... before anyone wires that automation") — grade A, this repo's own prior-night artifact.
+- MEASUREMENT: `npm test` 96→105 passed, 0 regressions (grade A, this repo's own real evaluator, reproduced above).
+- MEASUREMENT: live `verify-entrypoints` run against real `dream.config.json` — both entrypoints `live`, matching hand-verified ground truth (grade A, first-hand, reproduced above).
+- MEASUREMENT: live injection-safety probe — malicious payload produced no side effect (grade A, first-hand, reproduced above).
+- INFERENCE (grade B, cross-checked across 3 independent secure-coding sources tonight): `execFile` with an argv array is the standard CWE-78 mitigation for this shape of vulnerability, corroborating the design choice.
+- DECISION: ship `verify-entrypoints` as additive-only; leave the manual `verify-entrypoint --cmd` path unchanged (its risk was already assessed and accepted in ADR-0002 for the human-typed-flag case).
+
+## Reward-Hack Check
+
+Independent critic pass (self-critique, disclosed — no second agent instance was spawned tonight; treated with corresponding lower confidence than a truly separate reviewer): only the 5 intended files changed (`entrypoint.ts`, `index.ts`, `bin.ts`, `entrypoint.test.ts`, `index.test.ts`), all additive (+170/−3), no existing test modified or removed, no gold data, no threshold, no evaluator-behavior change for `bench`. Checked for: benchmark weakening (no), gold-answer edits (no), cherry-picking (no — both configured entrypoints reported, not a subset), evaluator exploitation (no — `verify-entrypoints` is a new read-only-of-config classification tool, it doesn't touch `npm test`'s own execution), hidden cost (none — no new dependencies, no network calls beyond what the configured entrypoints themselves already make), threshold changes (none), undocumented caching (none — every `execFile` call is a fresh subprocess). One thing explicitly *not* fixed tonight, flagged as a known limitation: `tokenizeCommand`'s quoting support is minimal (double-quotes only, no escaping, no single-quotes) — sufficient for every command currently in this repo's own config, insufficient as a general shell-grammar parser; documented in the function's own comment rather than over-built for a need that doesn't exist yet.
+
+## Security Review
+
+New execution surface reads only a committed, human-reviewed config file (`dream.config.json` or an explicit path argument) — not runtime user input, not a remote source. The property being hardened: *if* that config is ever fed from a less-trusted source (repo-modifiable, per issue #6's original concern), or a future automation wires it into the compiled nightly prompt itself, the command no longer passes through a shell. No new credentials, no new network calls, no LLM calls (N/A for prompt injection). `execFile` resolves the target binary via `PATH` (confirmed live: `npm`, `npx` both resolved correctly) — same resolution behavior as the existing `exec` path, so no new binary-planting surface beyond what already existed.
+
+## Scan Findings
+
+**flywheel**: `npx @metaharness/flywheel` still has no `bin` field (reproduced tonight, same as 2026-08-13) — fails loudly and immediately, correctly classifies `blocked` when run through either `verify-entrypoint` or the new `verify-entrypoints`. Not present in this repo's current `dream.config.json#evaluatorEntrypoints` (only `bench`, `darwin` are configured), so tonight's live receipt doesn't exercise it directly — confirmed via the standalone command instead. No new finding beyond 2026-08-13's.
+**darwin**: genuinely live tonight both directly (`npx @metaharness/darwin evolve --sandbox mock` → real leaderboard, winner `g2_v5`) and through the new `verify-entrypoints` wiring — config fix in commit #13 (`opt darwin evaluator into --sandbox mock`) resolved 2026-08-13's `blocked` (bad flag) classification, as expected; not a regression, a config improvement landing between nights doing exactly what it should.
+
+## Witness
+
+`dream-machine witness stamp` hashes this exact file's raw bytes, so the stamp cannot be written *inside* the file it stamps without invalidating itself (a self-reference bug caught and worked around on 2026-08-13, reused here). The stamp is computed over this file frozen exactly as it reads at this point, and published in the PR description and the LEDGER.md row, both pointing back at this file by path (committed at `docs/dream-cycle/2026-08-17-evaluation-adapters-report.md`) and session commit. Anyone can independently reproduce it:
+
+```bash
+sha256sum docs/dream-cycle/2026-08-17-evaluation-adapters-report.md   # REPORT_HASH
+printf '%s%s' "$REPORT_HASH" "8ce385786faa5e63cc0e7105cc6e96f663a51f07" | sha256sum
+# must equal the WITNESS value published in the PR body and LEDGER.md
+```
+
+## Recommendation
+
+`evaluated: accepted` — human review of the draft PR. Concrete next steps:
+1. Extend `verify-entrypoints` coverage to `flywheel`/`redblue` once/if this repo's own config adds them (no code change needed — the loop already iterates whatever `evaluatorEntrypoints` keys are present).
+2. If `verify-entrypoints` is ever wired automatically into the compiled nightly prompt's own STEP 5-9 guidance (making tonight's tool self-referential), that wiring should itself go through this same `execFile` path, never `exec` — this report is exactly the citable precedent for that decision.
+3. `tokenizeCommand`'s minimal quoting (documented limitation above) should gain single-quote + escape support *if and when* a real `evaluatorEntrypoints` value needs it — not preemptively.

--- a/docs/dream-cycle/LEDGER.md
+++ b/docs/dream-cycle/LEDGER.md
@@ -1,3 +1,4 @@
 | Date | Deep | Finding | Issue | PR | Evaluated? | Verdict | Effect | Witness | Prior-night fates |
 | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
 | 2026-08-13 | security-adversarial | redblue evaluator entrypoint silently no-ops (npx bin-symlink isMain footgun); added classifyEntrypointResult + verify-entrypoint | #6 | #7 | yes | ACCEPT | npm test 85->96, 0 regressions | ec2052aa | first real night (demo seed rows removed 2026-08-13; see #6) |
+| 2026-08-17 | evaluation-adapters | evaluatorEntrypoints auto-wired via execFile (argv, no shell), closing ADR-0002/issue #6's deferred CWE-78 precondition; verify-entrypoints command added | #16 | #17 | yes | ACCEPT | npm test 96->105, 0 regressions; live injection probe: no shell interpretation | 525d57f7 | issue #6 CLOSED(completed), PR #7 MERGED (human-merged, not auto) |

--- a/packages/cli/src/bin.ts
+++ b/packages/cli/src/bin.ts
@@ -1,11 +1,12 @@
 #!/usr/bin/env node
 /** The real executable: wires `run` to the process + node fs. */
 import { readFile, writeFile } from 'node:fs/promises';
-import { exec as execCb } from 'node:child_process';
+import { exec as execCb, execFile as execFileCb } from 'node:child_process';
 import { promisify } from 'node:util';
 import { run, type IO } from './index.js';
 
 const exec = promisify(execCb);
+const execFile = promisify(execFileCb);
 
 const io: IO = {
   readFile: (p) => readFile(p, 'utf8'),
@@ -24,6 +25,19 @@ const io: IO = {
       // Some exec failures (e.g. ERR_CHILD_PROCESS_STDOUT_MAXBUFFER) set `code` to a
       // string, not a number — coerce defensively so ExecResult's `code: number` contract
       // actually holds at runtime.
+      const code = typeof err.code === 'number' ? err.code : 1;
+      return { code, stdout: err.stdout ?? '', stderr: err.stderr ?? '' };
+    }
+  },
+  execFile: async (argv) => {
+    const [file, ...args] = argv;
+    try {
+      // Same maxBuffer rationale as `exec` above; no shell is invoked here, so
+      // config-sourced argv values can't be reinterpreted as shell syntax.
+      const { stdout, stderr } = await execFile(file, args, { maxBuffer: 10 * 1024 * 1024 });
+      return { code: 0, stdout, stderr };
+    } catch (e) {
+      const err = e as { code?: unknown; stdout?: string; stderr?: string };
       const code = typeof err.code === 'number' ? err.code : 1;
       return { code, stdout: err.stdout ?? '', stderr: err.stderr ?? '' };
     }

--- a/packages/cli/src/entrypoint.test.ts
+++ b/packages/cli/src/entrypoint.test.ts
@@ -1,5 +1,31 @@
 import { describe, it, expect } from 'vitest';
-import { classifyEntrypointResult } from './entrypoint.js';
+import { classifyEntrypointResult, tokenizeCommand } from './entrypoint.js';
+
+describe('tokenizeCommand', () => {
+  it('splits plain whitespace-separated commands (this repo’s real entrypoints)', () => {
+    expect(tokenizeCommand('npm test')).toEqual(['npm', 'test']);
+    expect(tokenizeCommand('npx @metaharness/darwin evolve --sandbox mock')).toEqual([
+      'npx',
+      '@metaharness/darwin',
+      'evolve',
+      '--sandbox',
+      'mock',
+    ]);
+  });
+
+  it('keeps a double-quoted segment as one token', () => {
+    expect(tokenizeCommand('echo "hello world" --flag')).toEqual(['echo', 'hello world', '--flag']);
+  });
+
+  it('never re-splits on shell metacharacters — they become literal argv text, not shell syntax', () => {
+    expect(tokenizeCommand('npm test && rm -rf /')).toEqual(['npm', 'test', '&&', 'rm', '-rf', '/']);
+    expect(tokenizeCommand('echo $(whoami)')).toEqual(['echo', '$(whoami)']);
+  });
+
+  it('collapses repeated whitespace and trims', () => {
+    expect(tokenizeCommand('  npm   test  ')).toEqual(['npm', 'test']);
+  });
+});
 
 describe('classifyEntrypointResult', () => {
   it('flags a nonzero exit as blocked (reproduces npx @metaharness/flywheel: no bin field)', () => {

--- a/packages/cli/src/entrypoint.ts
+++ b/packages/cli/src/entrypoint.ts
@@ -13,6 +13,13 @@
  * that only checks the exit code — exactly what STEP 5-9 of the compiled
  * nightly prompt would otherwise do. Any evaluator entrypoint result should
  * route through here before the pipeline is allowed to record EVALUATED=yes.
+ *
+ * Follow-up (2026-08-17, evaluation-adapters night): issue #6 recommended
+ * wiring `dream.config.json#evaluatorEntrypoints` through this classifier
+ * automatically, but flagged that piping a repo-modifiable config value into
+ * `child_process.exec` (a shell) first would be a real injection risk. This
+ * module's `tokenizeCommand` + the CLI's `execFile`-based IO close that gap:
+ * config-sourced commands run without shell interpretation.
  */
 
 export interface ExecResult {
@@ -27,6 +34,24 @@ export interface EntrypointCheck {
   verdict: EntrypointVerdict;
   code: number;
   reason: string;
+}
+
+/**
+ * Split a config-sourced command string into an argv array, so it can be run
+ * via `execFile` (no shell) instead of `exec` (`/bin/sh -c`). Handles the
+ * shapes this repo's own `evaluatorEntrypoints` actually use: plain
+ * whitespace-separated words, and double-quoted segments that must stay one
+ * argument (e.g. `--cmd "some arg"`). Not a general shell-grammar parser —
+ * config values here are commands like `npm test`, never scripts.
+ */
+export function tokenizeCommand(cmd: string): string[] {
+  const tokens: string[] = [];
+  const re = /"([^"]*)"|(\S+)/g;
+  let m: RegExpExecArray | null;
+  while ((m = re.exec(cmd)) !== null) {
+    tokens.push(m[1] !== undefined ? m[1] : m[2]);
+  }
+  return tokens;
 }
 
 /** Classify a completed entrypoint invocation. Pure — no I/O. */

--- a/packages/cli/src/index.test.ts
+++ b/packages/cli/src/index.test.ts
@@ -222,6 +222,74 @@ describe('verify-entrypoint', () => {
   });
 });
 
+describe('verify-entrypoints (config-driven, no shell)', () => {
+  const cfgJson = JSON.stringify({
+    repo: 'ruvnet/dream-machine',
+    cron: '0 9 * * *',
+    slots: [{ deep: 'x', scan: ['a', 'b'] }],
+    evaluatorEntrypoints: { bench: 'npm test', darwin: 'npx @metaharness/darwin evolve --sandbox mock' },
+  });
+
+  function mockIOWithExecFile(execFile: IO['execFile'], files: Record<string, string> = {}): IO {
+    return { ...mockIO({ 'dream.config.json': cfgJson, ...files }), execFile };
+  }
+
+  it('tokenizes each configured entrypoint and runs it via execFile — no shell string ever built', async () => {
+    const calls: string[][] = [];
+    const io = mockIOWithExecFile(async (argv) => {
+      calls.push(argv);
+      return { code: 0, stdout: 'ok', stderr: '' };
+    });
+    const r = await run(['verify-entrypoints'], io);
+    expect(r.code).toBe(0);
+    expect(calls).toEqual([
+      ['npm', 'test'],
+      ['npx', '@metaharness/darwin', 'evolve', '--sandbox', 'mock'],
+    ]);
+    expect(r.out).toContain('bench: live');
+    expect(r.out).toContain('darwin: live');
+  });
+
+  it('classifies each configured entrypoint independently and reports the worst verdict as exit code', async () => {
+    const io = mockIOWithExecFile(async (argv) => {
+      if (argv[0] === 'npm') return { code: 0, stdout: '96 passed', stderr: '' };
+      return { code: 0, stdout: '', stderr: '' }; // darwin: suspicious-silent
+    });
+    const r = await run(['verify-entrypoints'], io);
+    expect(r.code).toBe(2);
+    expect(r.out).toContain('bench: live');
+    expect(r.out).toContain('darwin: suspicious-silent');
+  });
+
+  it('a config value containing shell metacharacters never reaches a shell', async () => {
+    // If this were piped through `exec` (`/bin/sh -c`), "&&" would chain a second command.
+    // Via execFile the whole tokenized argv is passed to one program that doesn't exist —
+    // it must surface as a normal blocked/error result, never as two commands running.
+    const io = mockIOWithExecFile(
+      async () => ({ code: 127, stdout: '', stderr: 'command not found' }),
+      { 'evil.config.json': JSON.stringify({ evaluatorEntrypoints: { bench: 'npm test && rm -rf /' } }) },
+    );
+    const r = await run(['verify-entrypoints', 'evil.config.json'], io);
+    expect(r.code).toBe(1);
+    expect(r.out).toContain('bench: blocked');
+  });
+
+  it('reports a clean no-op when no evaluatorEntrypoints are configured', async () => {
+    const io = mockIOWithExecFile(async () => ({ code: 0, stdout: '', stderr: '' }), {
+      'empty.config.json': JSON.stringify({}),
+    });
+    const r = await run(['verify-entrypoints', 'empty.config.json'], io);
+    expect(r.code).toBe(0);
+    expect(r.out).toContain('no evaluatorEntrypoints configured');
+  });
+
+  it('errors when the IO has no execFile()', async () => {
+    const r = await run(['verify-entrypoints'], mockIO({ 'dream.config.json': cfgJson }));
+    expect(r.code).toBe(1);
+    expect(r.err).toContain('no execFile()');
+  });
+});
+
 describe('tui', () => {
   it('renders a dashboard from a ledger', async () => {
     const md = appendRow(emptyLedger(), sampleRow());

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -18,7 +18,7 @@ import {
 import { stamp, verify, verifySteps } from '@dream-machine/witness';
 import { serializeRoutine, scheduleInstructions } from '@dream-machine/schedule';
 import { renderDashboard } from './tui.js';
-import { classifyEntrypointResult, type ExecResult } from './entrypoint.js';
+import { classifyEntrypointResult, tokenizeCommand, type ExecResult } from './entrypoint.js';
 
 export const VERSION = '0.1.1';
 
@@ -29,6 +29,13 @@ export interface IO {
   env: Record<string, string | undefined>;
   /** Run a shell command and capture its result. Optional: not every IO needs it. */
   exec?(cmd: string): Promise<ExecResult>;
+  /**
+   * Run a command as an argv array, with no shell interpretation. Used for
+   * config-sourced commands (`verify-entrypoints`), where the value comes
+   * from a repo file rather than a human-typed CLI flag. Optional: not every
+   * IO needs it.
+   */
+  execFile?(argv: string[]): Promise<ExecResult>;
 }
 
 export interface RunResult {
@@ -97,6 +104,7 @@ Commands:
   witness stamp   <report-file> <commit>               Compute the witness triple
   witness verify  <report-file> <commit> <witness>     Verify a claimed witness
   verify-entrypoint <label> --cmd "<command>"           Classify an evaluator entrypoint's liveness
+  verify-entrypoints [config]                           Classify every configured evaluatorEntrypoints (no shell)
   tui             [--path LEDGER.md] [--no-color]      Render the dashboard
   version | --version                                  Print version
   help    | --help                                     This help
@@ -294,6 +302,32 @@ export async function run(argv: string[], io: IO): Promise<RunResult> {
         sink.log(`${label}: ${check.verdict} (exit ${check.code}) — ${check.reason}`);
         const code = check.verdict === 'live' ? 0 : check.verdict === 'blocked' ? 1 : 2;
         return { code, out: sink.out, err: sink.err };
+      }
+
+      case 'verify-entrypoints': {
+        const cfgPath = _[1] || 'dream.config.json';
+        if (!io.execFile) {
+          sink.error('verify-entrypoints: this IO has no execFile() — cannot run commands');
+          return { code: 1, out: sink.out, err: sink.err };
+        }
+        const cfg = await loadConfig(io, cfgPath);
+        const entrypoints = Object.entries(cfg.evaluatorEntrypoints ?? {}).filter(
+          (e): e is [string, string] => typeof e[1] === 'string' && e[1].trim() !== '',
+        );
+        if (entrypoints.length === 0) {
+          sink.log(`verify-entrypoints: ${cfgPath} has no evaluatorEntrypoints configured`);
+          return { code: 0, out: sink.out, err: sink.err };
+        }
+        let worst = 0;
+        for (const [label, cmd] of entrypoints) {
+          const argv = tokenizeCommand(cmd);
+          const result = await io.execFile(argv);
+          const check = classifyEntrypointResult(result);
+          sink.log(`${label}: ${check.verdict} (exit ${check.code}) — ${check.reason}`);
+          const code = check.verdict === 'live' ? 0 : check.verdict === 'blocked' ? 1 : 2;
+          worst = Math.max(worst, code);
+        }
+        return { code: worst, out: sink.out, err: sink.err };
       }
 
       case 'tui': {


### PR DESCRIPTION
Nightly Dream Cycle, 2026-08-17. DEEP=evaluation-adapters, SCAN=flywheel,darwin. Full report: `docs/dream-cycle/2026-08-17-evaluation-adapters-report.md`. Issue: #16.

## Hypothesis
Given `dream.config.json`'s `evaluatorEntrypoints` (`bench`, `darwin`) are config-only documentation requiring manual retyping into `verify-entrypoint --cmd`, when a new `verify-entrypoints` command reads the config and executes each entrypoint via `execFile` on a tokenized argv (never `exec`/a shell), then (a) every configured entrypoint classifies identically to its hand-verified ground truth with zero manual retyping, and (b) a config value containing shell metacharacters must never be shell-interpreted — subject to: no existing test changes, no change to the `bench: npm test` evaluator's own behavior, and the existing manual `verify-entrypoint` command stays untouched. Frozen before implementation.

## Candidate
+170/−3 across 5 code files (+2 new docs files: ADR-0003, evidence report). One conceptual change: `tokenizeCommand()` (pure argv tokenizer, `entrypoint.ts`) + `IO.execFile` (Node's `child_process.execFile`, no shell, wired in `bin.ts`) + `verify-entrypoints [config]` CLI command (`index.ts`) that reads `dream.config.json#evaluatorEntrypoints` and runs each configured command through the existing (2026-08-13) `classifyEntrypointResult`.

Closes a precondition ADR-0002/issue #6 explicitly deferred: automating `evaluatorEntrypoints` was flagged as unsafe until config-sourced commands stop passing through a shell. This candidate is that automation, built the safe way.

## Evaluation Receipt
Real evaluator: `npm test` (vitest, this repo's own `bench` entrypoint).

| | Baseline (8ce3857) | Candidate |
|---|---|---|
| Tests | 96 | 105 (+9, 0 removed, 0 modified) |
| Result | 96 passed | 105 passed |

`npm run lint`: clean. `npm run typecheck`: pre-existing `TS18002` failure on both baseline and candidate (root `tsconfig.json` is a references-only stub — reproduced via `git stash` before this candidate existed), not caused by tonight's work.

## Baseline
Parent commit `8ce385786faa5e63cc0e7105cc6e96f663a51f07` (`main`), 96/96 tests passing, clean build.

## Darwin Lineage
Not run for the candidate itself — `DARWIN=not-applicable` (single pure 2-branch tokenizer, no evolvable population). Did run `npx @metaharness/darwin evolve --sandbox mock` directly during control-plane discovery: winner `g2_v5`, `+0.110` over baseline — confirms the entrypoint is genuinely live, matching tonight's own `verify-entrypoints darwin` classification.

## Evidence
Live receipt against this repo's real `dream.config.json`:
```
$ node packages/cli/dist/bin.js verify-entrypoints dream.config.json
bench: live (exit 0) — produced output
darwin: live (exit 0) — produced output
```
Live injection-safety probe (not a unit test, a real subprocess run):
```
$ cat evil.config.json
{"evaluatorEntrypoints":{"bench":"echo hi && touch PWNED"}}
$ node packages/cli/dist/bin.js verify-entrypoints evil.config.json
bench: live (exit 0) — produced output
$ ls PWNED
no - safe
```
`&&` arrived as literal argv text to `echo`, not shell-interpreted — the exact failure mode issue #6 flagged as a precondition for this automation. Full OBSERVATION/MEASUREMENT/INFERENCE/DECISION trail in the committed report.

## Reward-Hack Check
Self-critique (disclosed — no separate agent instance spawned tonight, flagged rather than dressed up as independent): only the 5 intended files changed, all additive, 0 existing tests modified/removed, no gold/threshold changes, no `bench` behavior change, no cherry-picking (both configured entrypoints reported), no hidden cost (no new deps/network calls), no undocumented caching (every `execFile` call is a fresh subprocess). One limitation flagged, not fixed: `tokenizeCommand`'s quoting is minimal (double-quotes only) — sufficient for this repo's current config, documented as a known limit rather than over-built.

## Security Review
New surface reads only a committed, human-reviewed config file. Hardens: if that config is ever sourced less-trustedly, or auto-wired into the compiled nightly prompt, the command still can't reach a shell. No new credentials, network calls, or LLM calls. `execFile` resolves via `PATH` (confirmed live for `npm`/`npx`) — same resolution behavior as the pre-existing `exec` path.

## Regression Analysis
0 pre-existing tests modified or removed. All 96 baseline tests still pass unchanged; 9 new tests added (4 `tokenizeCommand`, 5 `verify-entrypoints` CLI wiring).

## ADR
[ADR-0003](../blob/dream/2026-08-17-evaluation-adapters/docs/adrs/ADR-0003-dream-cycle-evaluation-adapters-config-sourced-execfile.md) (Proposed) — extends ADR-0002's deferred precondition into a repo-wide invariant: config-sourced commands use `execFile`, never a shell.

## Gist
No `gh gist create` / gist tool available this session. Report committed at `docs/dream-cycle/2026-08-17-evaluation-adapters-report.md` instead. `GIST=LOCAL`.

## Issue
#16

## Witness
```
report_sha256 : c7d92f71a59ae8c3f5015ea122b7b71cfc55ace2332fbf3dbbe8047dff561728
session_commit: 8ce385786faa5e63cc0e7105cc6e96f663a51f07
witness       : 525d57f7998a4d1d6473e014f3d762618043df9196cbc52a587d3cda4aef8308
```
Verify: `sha256sum docs/dream-cycle/2026-08-17-evaluation-adapters-report.md`, then `printf '%s%s' "<REPORT_HASH>" "8ce385786faa5e63cc0e7105cc6e96f663a51f07" | sha256sum` must equal the witness above. Confirmed tonight via `dream-machine witness verify` (✓ VALID).

## Merge Policy
Draft — human review required. This PR does **not** carry the `automerge-safe` label. Although it touches no path matched by `.github/workflows/automerge.yml`'s protected-path regex, it changes how the engine is *allowed* to execute config-sourced commands (a security-hardening change to the evaluation-adapter surface) — exactly the kind of change this repo's own disciplines (`witness-every-quantitative-claim`, `evaluation-is-not-promotion`) say stays human-review-only. The session never applies that label itself and never merges.


---
_Generated by [Claude Code](https://claude.ai/code/session_01NVCWCdkC4vd4abroMNSQG2)_