### PR TITLE
security-adversarial: detect unpinned npx supply-chain risk in evaluator entrypoints

### DIFF
--- a/docs/dream-cycle/2026-08-18-security-adversarial-report.md
+++ b/docs/dream-cycle/2026-08-18-security-adversarial-report.md
@@ -1,0 +1,213 @@
+# Security-Adversarial / Supply-Chain SOTA Report — 2026
+
+**Repo:** ruvnet/dream-machine · **Date:** 2026-08-18 · **Slot:** 3 (DAYINT % 5)
+**DEEP:** security-adversarial · **SCAN:** redblue, supply-chain
+**Session commit (baseline):** `8ce385786faa5e63cc0e7105cc6e96f663a51f07`
+
+## TL;DR
+
+`dream.config.json#evaluatorEntrypoints.darwin` — this repo's own real, live Darwin
+evaluator entrypoint — is `npx @metaharness/darwin evolve --sandbox mock`, with no
+version pin. `npx` resolves the npm registry's `latest` dist-tag fresh on every
+invocation and is not governed by this repo's `package-lock.json` (that package isn't
+even a declared dependency). Live evidence tonight: `@metaharness/darwin` has shipped
+4 published versions and was last published 3 days ago (2026-08-15). Grade-A/B research
+confirms this is a live, current attack class (maintainer-account-compromise → malicious
+publish → auto-executed by every unpinned `npx` caller), not a hypothetical. Tonight's
+candidate adds a pure detector wired into the prompt compiler so every future compiled
+nightly routine surfaces this exposure automatically, before an autonomous agent (like
+this one) blindly executes an unpinned entrypoint. Detection only — remediation
+(pinning/vendoring) is left to human review, matching this repo's ADR-0002 precedent.
+
+## What's New
+
+- New pure module `packages/compile/src/supplychain.ts`:
+  `findUnpinnedNpxInvocations(controlPlaneProbes, evaluatorEntrypoints)`.
+- Wired into `packages/compile/src/index.ts`'s `step6to9Candidate` section — the
+  compiled prompt now includes a `**Supply-chain warning**` block naming any
+  offending entrypoint, with no change to which commands are actually executed.
+- Honors `npx --package=<spec>` / `-p <spec>` (the flag that overrides which package
+  npx actually resolves, independent of the bin-name token on the command line),
+  scans `npm exec` as an npx alias, and correctly excludes local-path and git/URL
+  package specs (not a registry-`latest` risk).
+- 17 new tests (`supplychain.test.ts` ×14, `index.test.ts` ×3), 0 removed/modified.
+
+## Competitors (how peers handle unpinned dynamic tool execution)
+
+| Project | Practice | Grade |
+|---|---|---|
+| Sakana AI Scientist | No documented entrypoint-pinning discipline found; runs experiment code from generated/cloned sources | C |
+| OpenHands | Runtime images are version-tagged (Docker digest pinning for the sandbox), but agent-invoked shell tools are not systematically scanned for unpinned `npx`/`pip run` style calls | C |
+| DSPy/GEPA | No evaluator-entrypoint supply-chain check found in official docs | C |
+| SWE-agent / SWE-bench | Uses pinned, versioned Docker images per task instance; does not address ad-hoc `npx` invocations because its harness doesn't shell out to arbitrary npm packages | B |
+| AutoGPT lineage | Historically broad, unsandboxed exec surface; no known built-in unpinned-invocation detector | C |
+
+No competitor documents a comparable "detect the compiled instructions' own unpinned
+dynamic-resolution commands before an agent executes them" step. Closest general
+prior art: OWASP's NPM Security Cheat Sheet explicit guidance to pin `npx pkg@version`
+instead of `npx pkg@latest` (Grade A, official, cheatsheetseries.owasp.org).
+
+## Hypothesis (frozen before implementation)
+
+> Given a compiled nightly routine prompt whose `evaluatorEntrypoints`/
+> `controlPlaneProbes` embed literal shell commands invoking `npx <pkg>` with no
+> pinned version, when a pure, deterministic detector classifies each such command
+> as PINNED (has an explicit `@<semver>`) vs UNPINNED (no version, or pinned only to
+> a floating dist-tag like `@latest`) and this detector is wired into the `compile`
+> step to emit a visible warning for every unpinned entrypoint, then every future
+> compiled nightly prompt should surface this known supply-chain exposure
+> automatically, before an autonomous agent executes it — subject to: no change to
+> any existing test, no change to the actual entrypoint commands executed tonight
+> (detection only, not remediation), and the detector must be pure/deterministic and
+> free of false positives/negatives against this repo's real `dream.config.json`.
+
+Not modified after evaluation began.
+
+## Benchmarks / Evaluation Receipt
+
+Real evaluator: `npm test` (vitest), this repo's own `bench` entrypoint.
+
+| | Baseline (parent, commit `8ce3857`) | Candidate |
+|---|---|---|
+| Test files | 7 | 8 |
+| Tests | 96 | 113 (+17, 0 removed, 0 modified) |
+| Result | 96 passed | 113 passed |
+| Build (`tsc -b` across all 6 packages) | clean | clean |
+
+Live end-to-end receipt: recompiling this repo's actual `dream.config.json` with the
+candidate code adds exactly a 3-line `**Supply-chain warning**` block naming
+`evaluatorEntrypoints.darwin` — verified with `diff` against the pre-candidate
+compiled output (`git diff` reproducible, see PR).
+
+Darwin evaluator entrypoint probed live tonight (`npx @metaharness/darwin evolve
+--sandbox mock`): LIVE, exit 0, produced a real leaderboard + lineage. `DARWIN=not-
+applicable` for this candidate itself — a single, already-minimal pure detector
+function has no meaningful mutable population for bounded generations×children
+search, same rationale as the 2026-08-13 precedent (ADR-0002).
+
+## Evidence
+
+- OBSERVATION (grade A, first-hand): `npm view @metaharness/darwin version` → `0.9.2`;
+  `npm view @metaharness/darwin versions --json` → `["0.8.3","0.9.0","0.9.1","0.9.2"]`;
+  `npm view @metaharness/darwin time.modified` → `2026-08-15T13:50:27.504Z` (3 days
+  before tonight); `npm view @metaharness/darwin dist-tags --json` → only `latest`
+  exists, no stable/pinned tag. `npm view @metaharness/darwin maintainers` →
+  single maintainer `ruvnet <ruv@ruv.net>`.
+- OBSERVATION (grade A/B, web research 2026-08-18): the Shai-Hulud/Miasma npm worm
+  lineage has repeatedly compromised maintainer GitHub/npm accounts and
+  self-propagated via fresh malicious publishes since late 2025, most recently
+  2026-08-04 against a ~127M-weekly-download package family (Aikido Security,
+  grade B, cross-checked against Trend Micro/Unit42/Splunk coverage of the same
+  campaign — grade B). At least 444 packages across 1381 versions have been hit.
+- OBSERVATION (grade A, official): OWASP NPM Security Cheat Sheet
+  (cheatsheetseries.owasp.org) states explicitly that `npx` does not consult the
+  lockfile and recommends `npx pkg@<version>` instead of `npx pkg@latest`.
+- MEASUREMENT: baseline 96/96 tests, candidate 113/113 tests, 0 regressions (see
+  Benchmarks above).
+- INFERENCE: a single-maintainer, correctly-scoped, non-typosquatted package (this
+  repo's own 2026-08-13 supply-chain scan conclusion for `@metaharness/*`) is still
+  fully exposed to this class of attack, because the exposure is about *pinning*,
+  not *identity* — the two are independent risk dimensions.
+- DECISION: ship the detector as a compile-time warning (visibility), not a silent
+  auto-pin (remediation stays a human/PR decision) — consistent with ADR-0002's
+  "classify, never silently trust or silently fix" precedent.
+
+## Reward-Hack Check (independent critic, separate agent context)
+
+**Verdict: CLEAR** of reward-hacking after one fix-and-reverify round.
+Independent critic (fresh subagent, not this candidate's author) verified the diff
+directly (`git diff`, file reads, its own `npx vitest run`), confirmed no
+gold/threshold/gate/automerge-protected path was touched, and confirmed the golden
+snapshot test was untouched (the existing fixture has no `npx` entrypoint, so the new
+code path is exercised only by new, honestly-separate test configs, not by mutating
+the golden fixture). It flagged real correctness bugs, not reward-hacking:
+
+1. **False positive**: `npx --package=@metaharness/darwin@0.9.2 darwin-evolve` (pinned)
+   was incorrectly flagged, because the original code took the *next* token after
+   `npx` as the package spec rather than honoring `--package=`.
+2. **False negative (serious)**: `npx --package=@metaharness/darwin run@1.0` (genuinely
+   unpinned) produced zero findings, because the bin-name token `run@1.0` was checked
+   instead of the actual `--package=` value.
+3. **Scope gap**: `npm exec @metaharness/darwin` (npm's own alias for `npx`, same
+   floating-resolution risk) was never scanned — only the literal `npx` token matched.
+4. **Misleading message**: `npx ./scripts/tool.js` (a local file, no registry
+   involved) was flagged with text claiming it "resolves the registry `latest`
+   dist-tag", which is false for a local-path invocation.
+
+All four were reproduced live by the critic against the actual function (not just
+reasoned about), fixed in `packages/compile/src/supplychain.ts`
+(`extractPackageSpec` now honors `--package=`/`-p`/`--package <spec>`;
+`isLocalOrRemoteSpec` excludes local/git/URL specs; the `npx` match now also accepts
+`npm exec`), and independently re-verified tonight by re-running the critic's exact
+four repro command strings directly against the rebuilt code (see PR — all four now
+resolve correctly). Six new regression tests lock in the fixes. Full suite re-run
+after the fix: 113/113 passed, 0 regressions, clean build.
+
+## Security Review
+
+No prompt injection surface (no LLM calls in this candidate). No tool/MCP authority
+change. No credential exposure — the detector only reads `dream.config.json` string
+fields already loaded by the existing `compile()` call, no new file/network access.
+No filesystem or network I/O added (`findUnpinnedNpxInvocations` and
+`extractPackageSpec`/`isUnpinned`/`isLocalOrRemoteSpec` are pure string functions).
+No change to `io.exec`/`verify-entrypoint`'s shell-exec path — this candidate adds
+detection text to the generated prompt only; it does not touch what actually gets
+executed. No agent impersonation, no benchmark/ledger poisoning (ledger and corpus
+files untouched by this diff). Supply-chain exposure is the subject of the finding,
+not introduced by it — the candidate reduces (does not increase) blind trust in an
+unpinned entrypoint by surfacing it before an agent relies on its result.
+
+## Scan Findings
+
+**redblue**: not independently re-probed tonight (candidate scope stayed on
+supply-chain per the frozen hypothesis; re-running the identical 2026-08-13
+`suspicious-silent` finding without new evidence would be a rediscovery, not a new
+measurement — explicitly avoided per STEP 2's "do not rediscover a failed direction
+unless new evidence justifies reopening it").
+
+**supply-chain**: this report's whole subject — `evaluatorEntrypoints.darwin`'s
+unpinned `npx @metaharness/darwin` invocation is a live, current exposure (evidence
+above). New: this is a *pinning* gap, orthogonal to the *identity* finding
+(no typosquat/dependency-confusion risk) the 2026-08-13 scan already closed for the
+same package family — both can be true at once, and only the second was addressed
+before tonight.
+
+## Gist
+
+No gist-creation MCP tool is available in this session (no `gh` CLI either). Report
+committed instead at `docs/dream-cycle/2026-08-18-security-adversarial-report.md`.
+`GIST=LOCAL`.
+
+## Witness
+
+`dream-machine witness stamp` hashes this exact file's raw bytes, so the stamp
+cannot be written *inside* the file it stamps (editing the file after hashing
+would invalidate the hash against the committed bytes — same self-reference
+issue already documented in `docs/dream-cycle/2026-08-13-security-adversarial-report.md`).
+The stamp is therefore computed over this file frozen exactly as it reads at
+this point, and published instead in the PR description and the LEDGER.md row,
+both of which point back at this file (committed at
+`docs/dream-cycle/2026-08-18-security-adversarial-report.md`) by path and
+session commit. Anyone can independently reproduce it:
+
+```bash
+sha256sum docs/dream-cycle/2026-08-18-security-adversarial-report.md   # REPORT_HASH
+printf '%s%s' "$REPORT_HASH" "8ce385786faa5e63cc0e7105cc6e96f663a51f07" | sha256sum
+# must equal the WITNESS value published in the PR body and LEDGER.md
+```
+
+## 3 Concrete Next Steps
+
+1. **Human decision on remediation**: pin `dream.config.json#evaluatorEntrypoints.darwin`
+   to an exact version (e.g. `npx @metaharness/darwin@0.9.2 evolve --sandbox mock`), or
+   vendor `@metaharness/darwin` as a real, lockfile-pinned `devDependency` and invoke it
+   via `node_modules/.bin/` instead of `npx`. This candidate intentionally does not do
+   this itself (detection vs. remediation stays separated, human-decided).
+2. **Extend the detector's scope check** to `controlPlaneProbes`/`evaluatorEntrypoints`
+   entries that use `pip run`/`uvx`/`bunx`-style equivalents if/when this repo's
+   evaluators grow beyond the npm ecosystem — out of scope tonight (no such entrypoint
+   exists yet), tracked here so a future night doesn't have to rediscover the pattern.
+3. **Re-probe `npx @metaharness/redblue`** on a future security-adversarial night to
+   check whether the 2026-08-13 `suspicious-silent` finding still reproduces on
+   `redblue@0.1.6` (current registry version, confirmed tonight) — skipped tonight to
+   keep this candidate's scope to exactly one conceptual change.

--- a/docs/dream-cycle/LEDGER.md
+++ b/docs/dream-cycle/LEDGER.md
@@ -1,3 +1,4 @@
 | Date | Deep | Finding | Issue | PR | Evaluated? | Verdict | Effect | Witness | Prior-night fates |
 | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
 | 2026-08-13 | security-adversarial | redblue evaluator entrypoint silently no-ops (npx bin-symlink isMain footgun); added classifyEntrypointResult + verify-entrypoint | #6 | #7 | yes | ACCEPT | npm test 85->96, 0 regressions | ec2052aa | first real night (demo seed rows removed 2026-08-13; see #6) |
+| 2026-08-18 | security-adversarial | npx supply-chain: unpinned evaluatorEntrypoints.darwin resolves registry latest every run; added compile-time detector (findUnpinnedNpxInvocations) | #18 | #19 | yes | ACCEPT | npm test 96->113, 0 regressions; compiled prompt now warns on unpinned npx entrypoints | e64046c951e7ef5fa7b72177bd9a6328df730610e5cca62397866168678ae123 | PR #7 MERGED (human, same night); issue #6 CLOSED |

--- a/packages/compile/src/index.test.ts
+++ b/packages/compile/src/index.test.ts
@@ -116,6 +116,28 @@ describe('compile', () => {
   it('golden-snapshot: metaharness prompt is stable', () => {
     expect(prompt).toMatchSnapshot();
   });
+
+  it('does not warn about unpinned npx when no entrypoint uses npx', () => {
+    expect(prompt).not.toContain('Supply-chain warning');
+  });
+
+  it('warns about an unpinned npx evaluator entrypoint (reproduces this repo\'s own dream.config.json)', () => {
+    const p = compile({
+      ...metaharness,
+      evaluatorEntrypoints: { darwin: 'npx @metaharness/darwin evolve --sandbox mock' },
+    });
+    expect(p).toContain('Supply-chain warning');
+    expect(p).toContain('evaluatorEntrypoints.darwin');
+    expect(p).toContain('npx @metaharness/darwin');
+  });
+
+  it('does not warn when the npx invocation is version-pinned', () => {
+    const p = compile({
+      ...metaharness,
+      evaluatorEntrypoints: { darwin: 'npx @metaharness/darwin@0.9.2 evolve --sandbox mock' },
+    });
+    expect(p).not.toContain('Supply-chain warning');
+  });
 });
 
 describe('defaults', () => {

--- a/packages/compile/src/index.ts
+++ b/packages/compile/src/index.ts
@@ -15,8 +15,10 @@ import {
   adrDir,
   adrPad,
 } from './config.js';
+import { findUnpinnedNpxInvocations } from './supplychain.js';
 
 export * from './config.js';
+export * from './supplychain.js';
 
 const LEDGER_SCHEMA = '| Date | Deep | Finding | Issue | PR | Evaluated? | Verdict | Effect | Witness | Prior-night fates |';
 
@@ -39,7 +41,7 @@ export function compile(config: DreamConfig): string {
   sections.push(step2Evidence(adrDir(c.adrConvention)));
   sections.push(step3Research(c.competitors));
   sections.push(step45Hypothesis());
-  sections.push(step6to9Candidate(c.evaluatorEntrypoints));
+  sections.push(step6to9Candidate(c.evaluatorEntrypoints, c.controlPlaneProbes));
   sections.push(step10to14Gates());
   sections.push(step15Security());
   sections.push(step16Witness());
@@ -235,11 +237,27 @@ hypothesis, benchmarks, evaluation, witness, 3 concrete next steps. No fabricate
 benchmarks; every quantitative claim carries its evidence grade.`;
 }
 
-function step6to9Candidate(ev: DreamConfig['evaluatorEntrypoints']): string {
+function step6to9Candidate(ev: DreamConfig['evaluatorEntrypoints'], probes: string[]): string {
   const evLines = Object.entries(ev ?? {})
     .filter(([, val]) => val)
     .map(([k, val]) => `- ${k}: \`${val}\``)
     .join('\n');
+  const unpinned = findUnpinnedNpxInvocations(probes, ev ?? {});
+  const unpinnedBlock = unpinned.length
+    ? '\n\n**Supply-chain warning — unpinned `npx` evaluator entrypoint(s):**\n' +
+      unpinned
+        .map(
+          (f) =>
+            `- \`${f.source}\` runs \`npx ${f.packageSpec}\` — no version pin. \`npx\` resolves the ` +
+            'registry `latest` dist-tag fresh on every invocation; it is not governed by this repo\'s ' +
+            'own lockfile. A compromised or bad publish under that package name executes immediately, ' +
+            'with no PR and no review. Treat a result from this entrypoint as evidence about "whatever ' +
+            'is latest right now", not a reproducible receipt, until it is pinned to an exact version or ' +
+            'vendored as a real dependency. Do not silently pin it yourself as part of an unrelated ' +
+            'candidate — flag it for human decision.',
+        )
+        .join('\n')
+    : '';
   return `# STEP 5–9: TESTABILITY GATE → CANDIDATE → BASELINE → EVALUATION
 
 If the finding is not testable tonight: \`EVALUATED=no / VERDICT=INCONCLUSIVE /
@@ -249,7 +267,7 @@ change), locate the committed benchmark corpus, evaluate the PARENT first on the
 real evaluator, then the candidate on the identical corpus/policy.
 
 Evaluator entrypoints for this repo:
-${evLines || '- (discover at runtime — none pinned in config)'}
+${evLines || '- (discover at runtime — none pinned in config)'}${unpinnedBlock}
 
 Do not infer results from logs. Preserve the real receipt. If evaluation is
 blocked by infrastructure/credentials: \`EVALUATED=blocked / VERDICT=INCONCLUSIVE\`

--- a/packages/compile/src/supplychain.test.ts
+++ b/packages/compile/src/supplychain.test.ts
@@ -1,0 +1,102 @@
+import { describe, it, expect } from 'vitest';
+import { findUnpinnedNpxInvocations } from './supplychain.js';
+
+describe('findUnpinnedNpxInvocations', () => {
+  it('flags this repo\'s real, current darwin entrypoint (reproduces dream.config.json)', () => {
+    const findings = findUnpinnedNpxInvocations([], {
+      bench: 'npm test',
+      darwin: 'npx @metaharness/darwin evolve --sandbox mock',
+    });
+    expect(findings).toHaveLength(1);
+    expect(findings[0]).toMatchObject({
+      source: 'evaluatorEntrypoints.darwin',
+      packageSpec: '@metaharness/darwin',
+    });
+  });
+
+  it('does not flag a pinned scoped package', () => {
+    const findings = findUnpinnedNpxInvocations([], {
+      darwin: 'npx @metaharness/darwin@0.9.2 evolve --sandbox mock',
+    });
+    expect(findings).toHaveLength(0);
+  });
+
+  it('flags an explicit @latest tag the same as no pin at all', () => {
+    const findings = findUnpinnedNpxInvocations(['npx cowsay@latest hi'], {});
+    expect(findings).toHaveLength(1);
+    expect(findings[0].packageSpec).toBe('cowsay@latest');
+  });
+
+  it('does not flag a pinned unscoped package', () => {
+    const findings = findUnpinnedNpxInvocations(['npx cowsay@1.2.3 hi'], {});
+    expect(findings).toHaveLength(0);
+  });
+
+  it('skips flags like -y when locating the package spec', () => {
+    const findings = findUnpinnedNpxInvocations(['npx -y @metaharness/redblue'], {});
+    expect(findings).toHaveLength(1);
+    expect(findings[0].packageSpec).toBe('@metaharness/redblue');
+  });
+
+  it('ignores commands with no npx token at all', () => {
+    const findings = findUnpinnedNpxInvocations(
+      ['npm ci && npm run build', 'npm test --silent 2>&1 | tail -5 || true'],
+      { bench: 'npm test' },
+    );
+    expect(findings).toHaveLength(0);
+  });
+
+  it('reports the source path for both probes and entrypoints', () => {
+    const findings = findUnpinnedNpxInvocations(['npx foo'], { darwin: 'npx @scope/bar' });
+    const sources = findings.map((f) => f.source).sort();
+    expect(sources).toEqual(['controlPlaneProbes[0]', 'evaluatorEntrypoints.darwin']);
+  });
+
+  it('does not flag undefined/empty entrypoints', () => {
+    const findings = findUnpinnedNpxInvocations([], { bench: undefined, flywheel: '' });
+    expect(findings).toHaveLength(0);
+  });
+
+  // Regression tests for issues found by an independent critic review of this same
+  // candidate (2026-08-18): `--package=`/`-p` names the package npx actually resolves,
+  // which can differ from the bin-name token that follows it on the command line.
+
+  it('does not flag a --package= invocation whose real spec is pinned (false-positive regression)', () => {
+    const findings = findUnpinnedNpxInvocations([], {
+      darwin: 'npx --package=@metaharness/darwin@0.9.2 darwin-evolve --sandbox mock',
+    });
+    expect(findings).toHaveLength(0);
+  });
+
+  it('flags a --package= invocation whose real spec is unpinned even if the bin name looks pinned (false-negative regression)', () => {
+    const findings = findUnpinnedNpxInvocations([], {
+      darwin: 'npx --package=@metaharness/darwin run@1.0',
+    });
+    expect(findings).toHaveLength(1);
+    expect(findings[0].packageSpec).toBe('@metaharness/darwin');
+  });
+
+  it('honors the short -p flag the same way as --package=', () => {
+    const findings = findUnpinnedNpxInvocations(['npx -p @scope/pkg@1.0.0 cmd'], {});
+    expect(findings).toHaveLength(0);
+  });
+
+  it('scans npm exec as an alias for npx (scope-gap regression)', () => {
+    const findings = findUnpinnedNpxInvocations(['npm exec @metaharness/darwin evolve'], {});
+    expect(findings).toHaveLength(1);
+    expect(findings[0].packageSpec).toBe('@metaharness/darwin');
+  });
+
+  it('does not flag a local file invocation (misleading-message regression)', () => {
+    const findings = findUnpinnedNpxInvocations(['npx ./scripts/tool.js'], {});
+    expect(findings).toHaveLength(0);
+  });
+
+  it('does not flag a direct git/URL package spec', () => {
+    const findings = findUnpinnedNpxInvocations(
+      ['npx git+https://github.com/foo/bar.git', 'npx github:foo/bar'],
+      {},
+    );
+    expect(findings).toHaveLength(0);
+  });
+});

--- a/packages/compile/src/supplychain.ts
+++ b/packages/compile/src/supplychain.ts
@@ -1,0 +1,120 @@
+/**
+ * Supply-chain: unpinned `npx` invocation detection.
+ *
+ * Reproduced 2026-08-18 (security-adversarial night, SCAN=supply-chain): this
+ * repo's own `dream.config.json#evaluatorEntrypoints.darwin` is
+ * `npx @metaharness/darwin evolve --sandbox mock` — no version pin. `npx`
+ * resolves against the registry's `latest` dist-tag fresh on every invocation;
+ * it does not consult (or get governed by) `package-lock.json`, so pinning a
+ * repo's *own* dependency tree does nothing to constrain what an unpinned
+ * `npx` call executes. `@metaharness/darwin` has published 4 versions in its
+ * history and was last published 3 days before tonight — evidence the "latest"
+ * an unpinned invocation resolves to is neither static nor rare to change.
+ * Live, current precedent for the blast radius: the Shai-Hulud/Miasma npm worm
+ * lineage has repeatedly compromised maintainer accounts and self-propagated
+ * via fresh publishes since late 2025, most recently 2026-08-04 (~127M
+ * weekly-download package family). None of that requires a typosquat or a
+ * dependency-confusion name collision — a single-maintainer, correctly-scoped
+ * package (which is exactly what this repo's own supply-chain scan on
+ * 2026-08-13 concluded `@metaharness/*` is) is still fully exposed if that
+ * maintainer's publish credential is ever compromised, because nothing here
+ * pins what gets executed.
+ *
+ * This module only detects and surfaces the exposure — it does not remediate
+ * it. Pinning `dream.config.json`'s actual entrypoints, or vendoring
+ * `@metaharness/*` as real lockfile-pinned dependencies, is a repo-owner
+ * decision left to human review (same "classify, don't silently trust or
+ * silently fix" precedent as ADR-0002).
+ */
+
+import type { EvaluatorEntrypoints } from './config.js';
+
+export interface UnpinnedNpxFinding {
+  /** Where the command came from, e.g. "evaluatorEntrypoints.darwin" or "controlPlaneProbes[1]". */
+  source: string;
+  /** The full shell command string it was found in. */
+  command: string;
+  /** The bare `npx` package spec token, e.g. "@metaharness/darwin" or "cowsay@latest". */
+  packageSpec: string;
+}
+
+/**
+ * True if a package spec is a local path or a direct git/URL reference —
+ * not a registry lookup, so "resolves `latest` from the registry" does not
+ * apply and it must never be flagged.
+ */
+function isLocalOrRemoteSpec(packageSpec: string): boolean {
+  return (
+    packageSpec.startsWith('.') ||
+    packageSpec.startsWith('/') ||
+    packageSpec.startsWith('~') ||
+    packageSpec.includes('://') ||
+    packageSpec.startsWith('git+') ||
+    packageSpec.startsWith('github:')
+  );
+}
+
+/** True if a package spec has no version pin, or is pinned to a floating dist-tag. */
+function isUnpinned(packageSpec: string): boolean {
+  const withoutScope = packageSpec.startsWith('@') ? packageSpec.slice(1) : packageSpec;
+  const atIndex = withoutScope.indexOf('@');
+  if (atIndex === -1) return true;
+  const version = withoutScope.slice(atIndex + 1);
+  // A real version pin starts with a digit (npm semver, no leading "v"). Anything else
+  // (empty, "latest", "next", a range like ">=1.0.0") is still a floating resolution.
+  return version === '' || !/^\d/.test(version);
+}
+
+/**
+ * Find the package spec `npx`/`npm exec` would resolve for one invocation
+ * starting at `tokens[start]` (the token right after the trigger). Honors
+ * `--package=<spec>` / `--package <spec>` / `-p <spec>` — npx's own flag for
+ * naming a *different* package than the one on the command line (e.g.
+ * `npx --package=@metaharness/darwin@0.9.2 darwin-evolve`, where the bin name
+ * `darwin-evolve` is not the package spec at all). Falls back to the first
+ * non-flag token when no `--package`/`-p` is present.
+ */
+function extractPackageSpec(tokens: string[], start: number): string | undefined {
+  for (let j = start; j < tokens.length; j++) {
+    const t = tokens[j];
+    if (t === '--package' || t === '-p') return tokens[j + 1];
+    if (t.startsWith('--package=')) return t.slice('--package='.length);
+    if (t.startsWith('-')) continue; // some other flag, e.g. -y — keep scanning
+    return t; // first non-flag token with no --package override
+  }
+  return undefined;
+}
+
+/**
+ * Scan `controlPlaneProbes` and `evaluatorEntrypoints` command strings for
+ * `npx <pkg>` / `npm exec <pkg>` invocations lacking an exact version pin.
+ * Pure — no I/O, no network. Local paths (`npx ./script.js`) and direct
+ * git/URL specs are never flagged — they don't resolve against the registry's
+ * floating `latest`, so the risk this function detects doesn't apply to them.
+ */
+export function findUnpinnedNpxInvocations(
+  controlPlaneProbes: string[],
+  evaluatorEntrypoints: EvaluatorEntrypoints,
+): UnpinnedNpxFinding[] {
+  const sources: Array<[string, string]> = [
+    ...controlPlaneProbes.map((cmd, i): [string, string] => [`controlPlaneProbes[${i}]`, cmd]),
+    ...(Object.entries(evaluatorEntrypoints) as Array<[string, string | undefined]>)
+      .filter((e): e is [string, string] => Boolean(e[1]))
+      .map(([key, cmd]): [string, string] => [`evaluatorEntrypoints.${key}`, cmd]),
+  ];
+
+  const findings: UnpinnedNpxFinding[] = [];
+  for (const [source, command] of sources) {
+    const tokens = command.split(/\s+/).filter(Boolean);
+    for (let i = 0; i < tokens.length; i++) {
+      const isNpx = tokens[i] === 'npx';
+      const isNpmExec = tokens[i] === 'npm' && tokens[i + 1] === 'exec';
+      if (!isNpx && !isNpmExec) continue;
+      const packageSpec = extractPackageSpec(tokens, i + (isNpmExec ? 2 : 1));
+      if (packageSpec && !isLocalOrRemoteSpec(packageSpec) && isUnpinned(packageSpec)) {
+        findings.push({ source, command, packageSpec });
+      }
+    }
+  }
+  return findings;
+}


### PR DESCRIPTION
Nightly Dream Cycle, 2026-08-18. DEEP=security-adversarial, SCAN=redblue,supply-chain. Full report: `docs/dream-cycle/2026-08-18-security-adversarial-report.md`. Issue: #18.

## Hypothesis
Given a compiled nightly routine prompt whose `evaluatorEntrypoints`/`controlPlaneProbes` embed literal shell commands invoking `npx <pkg>` with no pinned version, when a pure, deterministic detector classifies each such command as PINNED vs UNPINNED and is wired into the `compile` step to emit a visible warning for every unpinned entrypoint, then every future compiled nightly prompt should surface this known supply-chain exposure automatically, before an autonomous agent executes it — subject to: no change to any existing test, no change to the actual entrypoint commands executed tonight (detection only, not remediation), and the detector must be false-positive/false-negative-free against this repo's real `dream.config.json`. Frozen before implementation.

## Candidate
+478/-3 across 5 files (2 new source files, 1 new test file, 1 committed report, 2 small wiring edits). One conceptual change: `packages/compile/src/supplychain.ts` (pure detector: `findUnpinnedNpxInvocations`) + wiring into `step6to9Candidate` in `packages/compile/src/index.ts`.

## Evaluation Receipt
Real evaluator: `npm test` (vitest, this repo's own `bench` entrypoint).

| | Baseline (parent `8ce3857`) | Candidate |
|---|---|---|
| Tests | 96 | 113 (+17, 0 removed/modified) |
| Result | 96 passed | 113 passed |

Live end-to-end receipt: recompiling this repo's real `dream.config.json` with the candidate adds exactly a 3-line `**Supply-chain warning**` block naming `evaluatorEntrypoints.darwin` (its real, unpinned `npx @metaharness/darwin` entrypoint) — verified with `diff` against the pre-candidate compiled output.

## Baseline
Parent commit `8ce385786faa5e63cc0e7105cc6e96f663a51f07`, 96/96 tests passing, clean build.

## Darwin Lineage
Not run — `DARWIN=not-applicable`. Probed live tonight (`npx @metaharness/darwin evolve --sandbox mock` → real leaderboard, LIVE), but no evolvable population exists for a single, already-minimal pure detector function — same rationale as 2026-08-13/ADR-0002.

## Evidence
Reproduced live tonight (grade A, first-hand): `npm view @metaharness/darwin` shows version `0.9.2`, 4 published versions (`0.8.3`→`0.9.2`), last published 2026-08-15 (3 days before tonight), single maintainer `ruvnet`, only a `latest` dist-tag exists. Grade A/B research: OWASP's official NPM Security Cheat Sheet explicitly warns `npx` bypasses the lockfile and to pin `npx pkg@<version>`, not `npx pkg@latest`; the Shai-Hulud/Miasma npm worm lineage has repeatedly compromised maintainer accounts and self-propagated via fresh malicious publishes since late 2025, most recently 2026-08-04 against a ~127M-weekly-download package family. Full evidence trail with grades in the committed report.

## Reward-Hack Check
Independent critic (separate agent, not this candidate's author) reviewed the diff firsthand (`git diff`, file reads, its own `npx vitest run`) and reported **FLAGGED with real correctness bugs, CLEAR of reward-hacking**:
1. False positive: `npx --package=@metaharness/darwin@0.9.2 darwin-evolve` (pinned) was incorrectly flagged — the original code checked the bin-name token instead of the `--package=` value.
2. False negative (serious): `npx --package=@metaharness/darwin run@1.0` (genuinely unpinned) produced zero findings, same root cause.
3. Scope gap: `npm exec @metaharness/darwin` (npx's own alias, same risk) was never scanned.
4. Misleading message: `npx ./scripts/tool.js` (local file, no registry involved) was flagged with text claiming it "resolves the registry `latest` dist-tag".

No gold/threshold/gate/automerge-protected path was touched; the golden snapshot test is untouched (the existing fixture has no `npx` entrypoint, so the new code path is exercised only by new, honestly-separate test configs). All 4 bugs fixed in `packages/compile/src/supplychain.ts` (`extractPackageSpec` now honors `--package=`/`-p`/`--package <spec>`; `isLocalOrRemoteSpec` excludes local/git/URL specs; the match now also accepts `npm exec`) and independently re-verified by re-running the critic's exact 4 repro strings directly against the rebuilt code — all four now resolve correctly. 6 new regression tests lock in the fixes.

## Security Review
No prompt injection surface (no LLM calls in this candidate). No credential exposure, no new filesystem/network I/O — the detector is a pure string-only function over already-loaded config fields. No change to `io.exec`/`verify-entrypoint`'s actual shell-exec path; this candidate only adds text to the generated prompt, not to what gets executed.

## Regression Analysis
0 pre-existing tests modified or removed. All 96 baseline tests still pass unchanged; 17 new tests added (14 pure-detector incl. 6 critic-bug regressions, 3 compiler-wiring).

## ADR
None. This is a compile-time detection/warning addition, not a new architectural decision — it extends ADR-0002's "classify, don't silently trust or silently fix" precedent within the existing architecture rather than introducing a new invariant or gate.

## Gist
No `gh gist create` available this session (no gist tool, no `gh` CLI in this environment, same as 2026-08-13). Report committed at `docs/dream-cycle/2026-08-18-security-adversarial-report.md` instead. `GIST=LOCAL`.

## Issue
#18

## Witness
```
report_sha256 : 37e582b0fd9bb93bece762e8bd4095a33a317e5a2d6b17922b1c862d6b0daf37
session_commit: 8ce385786faa5e63cc0e7105cc6e96f663a51f07
witness       : e64046c951e7ef5fa7b72177bd9a6328df730610e5cca62397866168678ae123
```
Verify: `sha256sum docs/dream-cycle/2026-08-18-security-adversarial-report.md`, then `printf '%s%s' "<that hash>" "8ce385786faa5e63cc0e7105cc6e96f663a51f07" | sha256sum` must equal the witness above. Confirmed tonight via `dream-machine witness verify` (✓ VALID).

## Merge Policy
Draft — human review required. This PR does **not** carry the `automerge-safe` label: it adds a new compile-time behavior (the compiler now emits an extra warning block whenever a future config has an unpinned entrypoint), which is a judgment call about tonight's own scan finding, not touched by the repo's protected-path list, but still substantive enough to warrant a human read rather than an automatic merge. The session never merges and never applies that label itself.

---
_Generated by [Claude Code](https://claude.ai/code/session_01N8h2KCGNrsJdFRq8432RrK)_