### PR TITLE
developer-experience: thread real merge state into zero-merge learning signal (cli, tui)

### DIFF
--- a/docs/dream-cycle/2026-08-24-developer-experience-report.md
+++ b/docs/dream-cycle/2026-08-24-developer-experience-report.md
@@ -1,0 +1,103 @@
+# Developer Experience (CLI/TUI) SOTA Report — 2026
+
+## TL;DR
+The Dream Machine's own `learningSignals()` library function already supports
+threading real GitHub merge state (`mergedPrNumbers`) into the `zeroMergeStreak`
+signal, and is tested at the library level — but neither CLI consumer
+(`ledger signals`, `tui`) ever wires it. Every call defaults `mergedPrNumbers`
+to `undefined`, which the signal logic treats as "nothing merged," so
+`zeroMergeStreak` is **unconditionally true** whenever any PR number appears
+in the ledger window, merged or not. Verified live tonight: PR #7 (2026-08-13
+night) is `merged` per the GitHub API, yet `dream-machine tui` still renders
+"⚠ zero merges in 1 nights". This silently defeats STEP 1.1 of this repo's
+own compiled nightly prompt ("zero of the last 14 candidate PRs merged → bias
+to a tiny, easily-reviewable candidate") — the bias signal cannot ever turn
+off while any PR has been filed.
+
+## What's new
+- Confirmed root cause: `packages/cli/src/index.ts` `ledger signals` case
+  calls `learningSignals(rows)` with no `SignalOptions`; `packages/cli/src/tui.ts`
+  `renderDashboard` calls `learningSignals(rows)` the same way. Neither exposes
+  a way to supply merged-PR ground truth, despite `packages/ledger/src/index.ts`
+  having carried the `mergedPrNumbers` option (and dedicated tests) since it
+  was authored.
+- Grade A, first-hand, reproduced tonight:
+  `node packages/cli/dist/bin.js tui --path docs/dream-cycle/LEDGER.md` →
+  "⚠ zero merges in 1 nights", cross-checked against
+  `mcp__github__pull_request_read` on PR #7 → `"merged": true`.
+
+## Competitors (developer-experience / nightly-agent tooling)
+| Project | Comparable signal-wiring practice | Grade |
+|---|---|---|
+| Sakana AI Scientist | No persistent cross-run ledger with GitHub-state-aware signals found in public docs | B |
+| OpenHands | Session/task tracking, no PR-merge-aware bias signal documented | C |
+| SWE-agent / SWE-bench | Evaluates PRs directly against gold patches; no analogous "merge streak" self-bias concept | C |
+| DSPy/GEPA | Optimizer tracks metric history, not external VCS merge state | B |
+| pytest | N/A — no cross-run learning signal at all | A (absence confirmed via official docs) |
+None of the surveyed competitors implement a "cross-night learning signal
+gated on real external merge state" pattern comparable to this repo's own
+design intent, so there's no prior art to borrow a fix from — this is a
+wiring bug internal to this repo's own architecture, not a missing pattern.
+
+## Hypothesis (frozen before implementation)
+Given the compiled STEP 1.1 instruction "zero of the last 14 candidate PRs
+merged → bias to a tiny, easily-reviewable candidate," when the `ledger
+signals` CLI command and `tui`/`renderDashboard` are extended to optionally
+accept real merge-state ground truth (`--merged <csv-of-pr-numbers>` on the
+CLI; `mergedPrNumbers` threaded through `DashboardOptions`) and thread it into
+the existing, already-tested `learningSignals(rows, { mergedPrNumbers })`
+library call, then supplying a ledger whose only PR is known-merged should
+report `zeroMergeStreak: false`, while the default (no `--merged` supplied)
+must remain byte-for-byte identical to today's behavior — subject to: no
+change to `learningSignals`' own pure logic (already correct per its tests),
+no weakening of any existing CLI/TUI test (including the existing
+"shows a zero-merge warning" test that locks in default behavior with no
+merge data supplied), and the change stays purely additive/opt-in.
+
+## Benchmarks / Evaluation
+Real evaluator: `npm test` (vitest), this repo's own `bench` entrypoint.
+See Evaluation Receipt in the PR/issue body for the baseline → candidate
+test count and pass/fail table (committed alongside this report, not
+duplicated here to avoid drift between the two).
+
+## Evidence
+OBSERVATION: `tui` output shows "zero merges" on a ledger row whose PR is
+merged (grade A, reproduced twice: once via CLI, once via GitHub API).
+MEASUREMENT: `npm test` baseline vs. candidate pass counts (see receipt).
+INFERENCE: this signal has never once been able to report `false` for this
+repo's real history, because no caller has ever supplied `mergedPrNumbers`.
+DECISION: wire an opt-in `--merged` flag through both CLI consumers.
+
+## Witness
+`dream-machine witness stamp` hashes this exact file's raw bytes, so the
+stamp cannot be written *inside* the file it stamps (editing the file after
+hashing invalidates the hash against the committed bytes — the same
+self-reference bug the 2026-08-13 precedent report already caught). The
+stamp is computed over this file frozen exactly as it reads at this point,
+and published instead in the PR description and the LEDGER.md row, both of
+which point back at this file (committed at
+`docs/dream-cycle/2026-08-24-developer-experience-report.md`) by path and
+session commit. Anyone can independently reproduce it:
+
+```bash
+sha256sum docs/dream-cycle/2026-08-24-developer-experience-report.md   # REPORT_HASH
+printf '%s%s' "$REPORT_HASH" "<SESSION_COMMIT>" | sha256sum
+# must equal the WITNESS value published in the PR body and LEDGER.md
+```
+
+No `gh gist create` tonight — no gist-creation tool and no `gh` CLI in this
+environment (GitHub API access is via MCP tools for issues/PRs only, same as
+the 2026-08-13 precedent). `GIST=LOCAL`.
+
+## Next steps
+1. Extend `dream.config.json`'s compiled STEP 1.1 guidance to explicitly
+   instruct the agent to pass `--merged` with GitHub-verified PR numbers each
+   night (out of scope tonight — a `packages/compile` prompt-template change
+   is its own conceptual surface).
+2. Consider persisting the last N nights' merged-PR-number ground truth
+   locally (e.g. in the ledger itself, or a sidecar file) so a future night
+   without live GitHub access can still compute an accurate signal.
+3. Audit other `learningSignals`-adjacent CLI/TUI surfaces (`duplicateDirections`,
+   `lowScoreStreak`, `blockedEvalStreak`) for the same "library supports it,
+   CLI never wires it" gap — `recentScores` (gist self-scores) has an identical
+   unwired `SignalOptions` field with no CLI consumer either.

--- a/docs/dream-cycle/LEDGER.md
+++ b/docs/dream-cycle/LEDGER.md
@@ -1,3 +1,4 @@
 | Date | Deep | Finding | Issue | PR | Evaluated? | Verdict | Effect | Witness | Prior-night fates |
 | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
 | 2026-08-13 | security-adversarial | redblue evaluator entrypoint silently no-ops (npx bin-symlink isMain footgun); added classifyEntrypointResult + verify-entrypoint | #6 | #7 | yes | ACCEPT | npm test 85->96, 0 regressions | ec2052aa | first real night (demo seed rows removed 2026-08-13; see #6) |
+| 2026-08-24 | developer-experience | zero-merge learning signal never wired to real GitHub state (CLI+TUI) | #26 | NONE | yes | ACCEPT | npm test 96->101, 0 regressions; zeroMergeStreak flips true->false with real merge state | 8218bdaf | issue #6 CLOSED, PR #7 MERGED (2026-08-13 night) |

--- a/docs/dream-cycle/LEDGER.md
+++ b/docs/dream-cycle/LEDGER.md
@@ -1,4 +1,4 @@
 | Date | Deep | Finding | Issue | PR | Evaluated? | Verdict | Effect | Witness | Prior-night fates |
 | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
 | 2026-08-13 | security-adversarial | redblue evaluator entrypoint silently no-ops (npx bin-symlink isMain footgun); added classifyEntrypointResult + verify-entrypoint | #6 | #7 | yes | ACCEPT | npm test 85->96, 0 regressions | ec2052aa | first real night (demo seed rows removed 2026-08-13; see #6) |
-| 2026-08-24 | developer-experience | zero-merge learning signal never wired to real GitHub state (CLI+TUI) | #26 | NONE | yes | ACCEPT | npm test 96->101, 0 regressions; zeroMergeStreak flips true->false with real merge state | 8218bdaf | issue #6 CLOSED, PR #7 MERGED (2026-08-13 night) |
+| 2026-08-24 | developer-experience | zero-merge learning signal never wired to real GitHub state (CLI+TUI) | #26 | #27 | yes | ACCEPT | npm test 96->101, 0 regressions; zeroMergeStreak flips true->false with real merge state | 8218bdaf | issue #6 CLOSED, PR #7 MERGED (2026-08-13 night) |

--- a/packages/cli/src/index.test.ts
+++ b/packages/cli/src/index.test.ts
@@ -133,6 +133,21 @@ describe('ledger', () => {
     const r = await run(['ledger', 'signals', '--path', 'L.md'], mockIO({ 'L.md': ledgerMd }));
     expect(JSON.parse(r.out)).toHaveProperty('zeroMergeStreak');
   });
+  it('signals defaults to zeroMergeStreak=true with no --merged (unconfirmed, not "confirmed unmerged")', async () => {
+    const md = appendRow(emptyLedger(), sampleRow({ pr: '#7', verdict: 'ACCEPT' }));
+    const r = await run(['ledger', 'signals', '--path', 'L.md'], mockIO({ 'L.md': md }));
+    expect(JSON.parse(r.out).zeroMergeStreak).toBe(true);
+  });
+  it('signals --merged reports zeroMergeStreak=false when the ledger PR is confirmed merged', async () => {
+    const md = appendRow(emptyLedger(), sampleRow({ pr: '#7', verdict: 'ACCEPT' }));
+    const r = await run(['ledger', 'signals', '--path', 'L.md', '--merged', '7'], mockIO({ 'L.md': md }));
+    expect(JSON.parse(r.out).zeroMergeStreak).toBe(false);
+  });
+  it('signals --merged tolerates a "#"-prefixed, comma-separated list', async () => {
+    const md = appendRow(emptyLedger(), sampleRow({ pr: '#12', verdict: 'ACCEPT' }));
+    const r = await run(['ledger', 'signals', '--path', 'L.md', '--merged', '#7, #12'], mockIO({ 'L.md': md }));
+    expect(JSON.parse(r.out).zeroMergeStreak).toBe(false);
+  });
   it('append writes a row (bootstraps ledger if missing)', async () => {
     const io = mockIO();
     const r = await run(
@@ -240,5 +255,17 @@ describe('tui', () => {
     for (let i = 0; i < 14; i++) md = appendRow(md, sampleRow({ pr: `#${i}`, verdict: 'INCONCLUSIVE' }));
     const frame = renderDashboard(md, { noColor: true });
     expect(frame).toContain('zero merges');
+  });
+  it('renderDashboard clears the zero-merge warning when mergedPrNumbers confirms the ledger PR merged', () => {
+    const md = appendRow(emptyLedger(), sampleRow({ pr: '#7', verdict: 'ACCEPT' }));
+    const frame = renderDashboard(md, { noColor: true, mergedPrNumbers: new Set(['7']) });
+    expect(frame).not.toContain('zero merges');
+    expect(frame).toContain('signals nominal');
+  });
+  it('tui --merged clears the zero-merge warning end-to-end', async () => {
+    const md = appendRow(emptyLedger(), sampleRow({ pr: '#7', verdict: 'ACCEPT' }));
+    const r = await run(['tui', '--path', 'L.md', '--no-color', '--merged', '7'], mockIO({ 'L.md': md }));
+    expect(r.code).toBe(0);
+    expect(r.out).not.toContain('zero merges');
   });
 });

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -91,18 +91,32 @@ Commands:
   compile [config] [--out FILE]                        Compile config → routine prompt
   schedule [config] [--out FILE] [--env ID]            Emit the /schedule routine body
   ledger verify   [--path LEDGER.md]                   Structurally verify a ledger
-  ledger signals  [--path LEDGER.md]                   Print STEP 1.1 learning signals
+  ledger signals  [--path LEDGER.md] [--merged 7,12]    Print STEP 1.1 learning signals
   ledger stats    [--path LEDGER.md]                   Verdict distribution
   ledger append   --path L --date .. --deep .. ...     Append one row
   witness stamp   <report-file> <commit>               Compute the witness triple
   witness verify  <report-file> <commit> <witness>     Verify a claimed witness
   verify-entrypoint <label> --cmd "<command>"           Classify an evaluator entrypoint's liveness
-  tui             [--path LEDGER.md] [--no-color]      Render the dashboard
+  tui             [--path LEDGER.md] [--no-color] [--merged 7,12]  Render the dashboard
   version | --version                                  Print version
   help    | --help                                     This help
 
 The Dream Machine never merges. Evaluation is not promotion — a human decides.
 Docs: https://ruvnet.github.io/dream-machine/`;
+
+/**
+ * Parse `--merged 7,#12, 30` into a bare-number Set for `learningSignals`'
+ * `mergedPrNumbers` option. Undefined input means "no ground truth supplied"
+ * (preserves the existing default: zero-merge streak reads as unconfirmed).
+ */
+function parseMergedPrNumbers(flag: string | boolean | undefined): Set<string> | undefined {
+  if (typeof flag !== 'string') return undefined;
+  const nums = flag
+    .split(',')
+    .map((s) => s.trim().replace(/^#/, ''))
+    .filter(Boolean);
+  return new Set(nums);
+}
 
 async function loadConfig(io: IO, path: string): Promise<DreamConfig> {
   const raw = await io.readFile(path);
@@ -197,7 +211,8 @@ export async function run(argv: string[], io: IO): Promise<RunResult> {
         }
         if (sub === 'signals') {
           const { rows } = parseLedger(md);
-          sink.log(JSON.stringify(learningSignals(rows), null, 2));
+          const mergedPrNumbers = parseMergedPrNumbers(flags.merged);
+          sink.log(JSON.stringify(learningSignals(rows, { mergedPrNumbers }), null, 2));
           return { code: 0, out: sink.out, err: sink.err };
         }
         if (sub === 'stats') {
@@ -304,7 +319,13 @@ export async function run(argv: string[], io: IO): Promise<RunResult> {
         } catch {
           md = emptyLedger();
         }
-        sink.log(renderDashboard(md, { noColor: flags['no-color'] === true, repo: flags.repo as string | undefined }));
+        sink.log(
+          renderDashboard(md, {
+            noColor: flags['no-color'] === true,
+            repo: flags.repo as string | undefined,
+            mergedPrNumbers: parseMergedPrNumbers(flags.merged),
+          }),
+        );
         return { code: 0, out: sink.out, err: sink.err };
       }
 

--- a/packages/cli/src/tui.ts
+++ b/packages/cli/src/tui.ts
@@ -38,6 +38,12 @@ export interface DashboardOptions {
   limit?: number;
   /** Repo name for the header. */
   repo?: string;
+  /**
+   * PR numbers confirmed merged (e.g. via the GitHub API), so the zero-merge
+   * signal reflects real state instead of defaulting to "nothing merged".
+   * See `learningSignals`' `mergedPrNumbers` option.
+   */
+  mergedPrNumbers?: Set<string>;
 }
 
 /** Render the dashboard framebuffer from a ledger markdown string. */
@@ -45,7 +51,7 @@ export function renderDashboard(ledgerMd: string, opts: DashboardOptions = {}): 
   const c = opts.noColor ? new Proxy({}, { get: () => '' }) as typeof C : C;
   const { rows } = parseLedger(ledgerMd);
   const stats = verdictStats(rows);
-  const signals = learningSignals(rows);
+  const signals = learningSignals(rows, { mergedPrNumbers: opts.mergedPrNumbers });
   const limit = opts.limit ?? 10;
   const recent = rows.slice(-limit).reverse();
   const total = rows.length;


### PR DESCRIPTION
Nightly Dream Cycle, 2026-08-24. DEEP=developer-experience, SCAN=cli,tui. Full report: `docs/dream-cycle/2026-08-24-developer-experience-report.md`. Issue: #26.

## Hypothesis
Given the compiled STEP 1.1 instruction "zero of the last 14 candidate PRs merged → bias to a tiny, easily-reviewable candidate," when the `ledger signals` CLI command and `tui`/`renderDashboard` are extended to optionally accept real merge-state ground truth (`--merged 7,12`) and thread it into the existing, already-tested `learningSignals(rows, { mergedPrNumbers })` library call, then a ledger whose only PR is known-merged should report `zeroMergeStreak: false`, while the default (no `--merged` supplied) remains byte-for-byte identical to prior behavior. Frozen before implementation.

## Candidate
+65/-6 across 3 source files (`packages/cli/src/index.ts`, `packages/cli/src/tui.ts`, `packages/cli/src/index.test.ts`) + 1 committed report. One conceptual change: a `parseMergedPrNumbers` CLI helper + `--merged` flag on `ledger signals` and `tui`, plus a `mergedPrNumbers` field on `DashboardOptions`. `packages/ledger/src/index.ts` (the library logic and its own tests) is untouched.

## Evaluation Receipt
Real evaluator: `npm test` (vitest, this repo's own `bench` entrypoint).

| | Baseline (8ce3857) | Candidate |
|---|---|---|
| Tests | 96 | 101 (+5, 0 removed/modified) |
| Result | 96 passed | 101 passed |

Live receipt against tonight's real ledger and PR #7's real (confirmed-merged) GitHub state:
```
$ node packages/cli/dist/bin.js ledger signals --path docs/dream-cycle/LEDGER.md
{ "zeroMergeStreak": true, ... }              # unpatched default, unchanged after the fix
$ node packages/cli/dist/bin.js ledger signals --path docs/dream-cycle/LEDGER.md --merged 7
{ "zeroMergeStreak": false, ... }             # matches ground truth
$ node packages/cli/dist/bin.js tui --path docs/dream-cycle/LEDGER.md --merged 7 --no-color
✓ signals nominal                              # was "⚠ zero merges in 1 nights"
```

## Baseline
Parent commit `8ce385786faa5e63cc0e7105cc6e96f663a51f07`, 96/96 tests passing, clean build.

## Darwin Lineage
Not run — `DARWIN=not-applicable`. No evolvable population for a small deterministic CLI-flag-wiring change; same judgment as the 2026-08-13 precedent (PR #7) for an analogous pure-function candidate.

## Evidence
OBSERVATION: `tui` renders "zero merges" for a ledger whose only PR (#7) is merged (grade A, reproduced twice: CLI output + GitHub API cross-check).
MEASUREMENT: `npm test` 96/96 → 101/101, 0 regressions, 0 pre-existing tests modified.
INFERENCE: this signal has never been able to report `false` for this repo's real history — a latent defect since the `mergedPrNumbers` option was authored, not introduced tonight.
DECISION: wire an opt-in `--merged` flag through both CLI consumers; library logic and its tests untouched.

## Reward-Hack Check
Independent critic (separate agent): **CLEAR** of reward-hacking. No existing test assertion touched/loosened (all 5 new tests additive); no evaluator gaming; no hidden cost/cache; no threshold/gate/safety constant touched (`packages/ledger/src/index.ts` has zero diff); default behavior (`--merged` omitted) verified byte-identical via code trace + dedicated regression test; `parseMergedPrNumbers` format matches `learningSignals`' own `prNumber()` extraction, no injection risk; test counts independently re-verified (96→101 exact match via `git stash` + rerun). Two minor non-blocking notes: `--merged` with no value silently no-ops rather than erroring, and non-numeric input degrades safely toward the conservative default — neither a correctness or security issue.

## Security Review
No new exec/network/credential surface. `parseMergedPrNumbers` is pure string parsing (split/trim/strip-`#`/filter), no eval, no shell interpolation, no external I/O. No LLM calls in this candidate.

## Regression Analysis
0 pre-existing tests modified or removed. All 96 baseline tests still pass unchanged; 5 new tests added (3 CLI `ledger signals`, 2 TUI/`renderDashboard`).

## ADR
None — this is a small CLI-flag wiring fix, not an architectural decision (per the compiled prompt's own guidance to skip ADRs for parameter/routing-level changes).

## Gist
No `gh gist create` available this session (no gist tool, no `gh` CLI in this environment — same as the 2026-08-13 precedent). Report committed at `docs/dream-cycle/2026-08-24-developer-experience-report.md` instead. `GIST=LOCAL`.

## Issue
#26

## Witness
```
report_sha256 : bc9df8e6737a10a267fc14959edf24f6842ddfd228fc3dc5452618c67899450f
session_commit: 8ce385786faa5e63cc0e7105cc6e96f663a51f07
witness       : 8218bdafced859fdddafa4b920fa00324062963864285b6155cbd1347e9fc426
```
Verify: `sha256sum docs/dream-cycle/2026-08-24-developer-experience-report.md`, then `printf '%s%s' "bc9df8e6737a10a267fc14959edf24f6842ddfd228fc3dc5452618c67899450f" "8ce385786faa5e63cc0e7105cc6e96f663a51f07" | sha256sum` must equal the witness above. Confirmed tonight via `dream-machine witness verify` (✓ VALID).

## Merge Policy
Draft — human review required. This PR does **not** carry the `automerge-safe` label: while the change itself is small, it modifies CLI argument parsing and a learning-signal computation the pipeline's own STEP 1.1 relies on, which is exactly the low-confidence-blast-radius case that stays human-review-only under this repo's guarded-auto-merge policy (`.github/workflows/automerge.yml`). The session never merges and never applies that label itself.

---
_Generated by [Claude Code](https://claude.ai/code/session_01RuH2ayp9QgVF2kKQtyQFMN)_