### PR TITLE
feat(witness): anchored trace replay for causal failure experiments

### DIFF
--- a/docs/adrs/ADR-0003-anchored-trace-replay.md
+++ b/docs/adrs/ADR-0003-anchored-trace-replay.md
@@ -1,0 +1,94 @@
+# ADR-0003: Anchored trace replay for causal failure experiments
+
+**Status:** Proposed  
+**Date:** 2026-08-27  
+**Related:** Dream Machine issue #41, ADR-0001, `@dream-machine/witness`
+
+## Context
+
+Long-horizon agent and multi-agent failures are stochastic. Re-running a failed workflow from the beginning changes both the proposed repair and the trajectory that led to the failure. A later success therefore does not establish that the repair caused the improvement.
+
+SymTrace, arXiv:2608.25920, makes this confound explicit. It records a trajectory, chooses an intervention anchor, reconstructs the prefix from recorded evidence, and regenerates only the suffix. The paper reports poor failure reproduction and repair from unguided whole-trajectory reruns and materially higher repair from symptom-driven anchored intervention. Those paper results are external evidence, not yet a RuV reproduction.
+
+Dream Machine already produces provenance witnesses and applies held-out promotion gates. It lacks a small reusable primitive that proves a repair experiment started from the same causal prefix.
+
+## Decision
+
+Add anchored trace replay receipts to `@dream-machine/witness`.
+
+A trace is an ordered sequence of JSON-safe events with unique ids and strictly increasing integer steps. An anchored replay binds:
+
+1. the digest and length of the immutable prefix before the intervention
+2. the exact anchor id, step, and evidence digest
+3. the digest of the original suffix for audit
+4. the digest of the complete original trace
+
+Before regenerated execution can be compared, the reconstructed prefix must match the anchored prefix exactly. The regenerated suffix must begin strictly after the anchor and cannot reuse immutable event ids. A successful finalize operation emits a deterministic receipt for the regenerated suffix and the combined candidate trace.
+
+The implementation uses canonical JSON plus SHA-256 and rejects unsupported or ambiguous evidence such as `undefined`, non-finite numbers, cycles, duplicate ids, and non-monotonic steps.
+
+## Authority boundary
+
+A trace digest proves evidence identity only. It grants no execution capability, tool permission, model permission, network access, filesystem access, deployment right, or promotion right. RVM or another authoritative runtime remains responsible for capability enforcement.
+
+A replay receipt may be an input to Dream Machine evaluation. It can never be sufficient evidence for autonomous merge or deployment.
+
+## Consequences
+
+Positive:
+
+* repair experiments can distinguish a changed downstream intervention from a changed upstream sample
+* failed prefixes become reproducible regression fixtures
+* the primitive is model- and framework-neutral
+* the existing witness package supplies provenance without adding dependencies
+
+Negative:
+
+* exact prefix equality is stricter than semantic equivalence and may reject valid replays when tools emit nondeterministic metadata
+* canonicalization requires JSON-safe evidence
+* deterministic replay can still fail when external systems cannot reconstruct the same pre-anchor state
+
+For nondeterministic external fields, callers must normalize them before trace creation and preserve both raw evidence and the normalization policy in higher-level provenance. The witness layer will not silently ignore fields.
+
+## Alternatives considered
+
+### Whole trajectory rerun
+
+Rejected as the default repair comparison because upstream resampling changes the experiment.
+
+### Semantic similarity of prefixes
+
+Rejected for the evidence boundary. Similarity is useful for retrieval but cannot prove causal-prefix identity.
+
+### Full deterministic simulator snapshot
+
+Desirable where available but not universal. Anchored trace replay is a smaller primitive that can bind simulator snapshots, tool receipts, or other state evidence without requiring a specific runtime.
+
+### New standalone package
+
+Rejected for the first implementation. The primitive is small, dependency-free, and provenance-oriented, so `@dream-machine/witness` is the narrowest existing home.
+
+## Test contract
+
+The implementation must prove:
+
+* deterministic canonical hashing independent of object key order
+* exact prefix acceptance
+* mutated prefix rejection
+* moved or modified anchor rejection
+* suffix boundary enforcement
+* immutable id collision rejection
+* duplicate and non-monotonic trace rejection
+* deterministic receipt generation
+* fail-closed behavior for unsupported evidence
+
+Repository CI, type checking, lint, and the existing witness tests must remain green.
+
+## Rollback
+
+The change is additive. Removing the exported trace replay module and this ADR restores prior behavior. It performs no data migration and changes no existing witness format.
+
+## References
+
+* SymTrace: `arXiv:2608.25920`, submitted 2026-08-26
+* Dream Machine issue #41

--- a/docs/adrs/INDEX.md
+++ b/docs/adrs/INDEX.md
@@ -21,6 +21,7 @@ Alternatives Considered → Test Contract → References.
 | [ADR-0105](./ADR-0105-mac-studio-codex-swarm-control-plane.md) | A Mac Studio and Codex desktop swarm form the governed development control plane | Proposed |
 | [ADR-0106](./ADR-0106-executable-software-prototype-and-evidence.md) | Executable software prototype and bounded evidence | Implemented for software prototype; hardware and research blocked |
 | [ADR-0004](./ADR-0004-evidence-carrying-termination.md) | Completion requires claim-level in-scope evidence and deterministic closed replay | Proposed |
+| [ADR-0003](./ADR-0003-anchored-trace-replay.md) | Anchored trace replay for causal failure experiments | Proposed |
 
 ## How to amend
 

--- a/packages/witness/src/index.ts
+++ b/packages/witness/src/index.ts
@@ -123,3 +123,4 @@ export function verifySteps(gistRawUrl = '<RAW_GIST_URL>'): string {
 export * from './security-patch.js';
 export * from './reconstruction.js';
 export * from './termination.js';
+export * from './trace-replay.js';

--- a/packages/witness/src/trace-replay.test.ts
+++ b/packages/witness/src/trace-replay.test.ts
@@ -26,6 +26,31 @@ describe('canonicalJson', () => {
     expect(() => canonicalJson({ a: undefined })).toThrow(/undefined/);
     expect(() => canonicalJson({ a: Number.NaN })).toThrow(/non-finite/);
   });
+
+  it('rejects ambiguous values that are not plain JSON evidence', () => {
+    const sparse = new Array(2);
+    sparse[1] = 'evidence';
+    expect(() => canonicalJson(sparse)).toThrow(/dense/);
+    expect(() => canonicalJson(new Date('2026-08-28T00:00:00Z'))).toThrow(/plain JSON object/);
+    expect(() => canonicalJson(new Map([['status', 500]]))).toThrow(/plain JSON object/);
+
+    const symbol = Symbol('hidden');
+    expect(() => canonicalJson({ visible: true, [symbol]: 'secret' })).toThrow(/symbol key/);
+  });
+
+  it('rejects accessors without invoking untrusted evidence code', () => {
+    let reads = 0;
+    const evidence = Object.defineProperty({}, 'status', {
+      enumerable: true,
+      get() {
+        reads += 1;
+        return 500;
+      },
+    });
+
+    expect(() => canonicalJson(evidence)).toThrow(/data property/);
+    expect(reads).toBe(0);
+  });
 });
 
 describe('anchored trace replay', () => {

--- a/packages/witness/src/trace-replay.test.ts
+++ b/packages/witness/src/trace-replay.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, it } from 'vitest';
+import {
+  canonicalJson,
+  createAnchoredReplay,
+  finalizeAnchoredReplay,
+  traceDigest,
+  verifyReplayPrefix,
+  type TraceEvent,
+} from './trace-replay.js';
+
+const trace: TraceEvent[] = [
+  { id: 'e0', step: 0, kind: 'input', input: { task: 'repair auth' } },
+  { id: 'e1', step: 1, kind: 'tool', actor: 'researcher', output: { file: 'auth.ts' } },
+  { id: 'e2', step: 2, kind: 'symptom', actor: 'tester', output: { status: 500 } },
+  { id: 'e3', step: 3, kind: 'repair', actor: 'coder', output: { patch: 'old' } },
+];
+
+describe('canonicalJson', () => {
+  it('sorts object keys so equivalent evidence hashes identically', () => {
+    expect(canonicalJson({ z: 1, a: { y: 2, x: 3 } })).toBe(
+      canonicalJson({ a: { x: 3, y: 2 }, z: 1 }),
+    );
+  });
+
+  it('fails closed on undefined and non-finite numbers', () => {
+    expect(() => canonicalJson({ a: undefined })).toThrow(/undefined/);
+    expect(() => canonicalJson({ a: Number.NaN })).toThrow(/non-finite/);
+  });
+});
+
+describe('anchored trace replay', () => {
+  it('binds the exact prefix, anchor, suffix, and full trace', () => {
+    const plan = createAnchoredReplay(trace, 'e2');
+    expect(plan.anchorId).toBe('e2');
+    expect(plan.anchorStep).toBe(2);
+    expect(plan.prefixLength).toBe(2);
+    expect(plan.prefixDigest).toBe(traceDigest(trace.slice(0, 2)));
+    expect(plan.originalSuffixDigest).toBe(traceDigest(trace.slice(3)));
+    expect(plan.originalTraceDigest).toBe(traceDigest(trace));
+  });
+
+  it('accepts only an exact reconstructed prefix', () => {
+    const plan = createAnchoredReplay(trace, 'e2');
+    expect(verifyReplayPrefix(plan, trace.slice(0, 2))).toEqual({ ok: true });
+
+    const mutated = structuredClone(trace.slice(0, 2));
+    mutated[1].output = { file: 'different.ts' };
+    expect(verifyReplayPrefix(plan, mutated)).toEqual({
+      ok: false,
+      reason: 'reconstructed prefix digest differs from anchored prefix',
+    });
+  });
+
+  it('rejects a moved or modified anchor', () => {
+    const plan = createAnchoredReplay(trace, 'e2');
+    expect(() =>
+      finalizeAnchoredReplay(plan, trace.slice(0, 2), { ...trace[2], step: 4 }, []),
+    ).toThrow(/anchor identity or step/);
+
+    expect(() =>
+      finalizeAnchoredReplay(
+        plan,
+        trace.slice(0, 2),
+        { ...trace[2], output: { status: 200 } },
+        [],
+      ),
+    ).toThrow(/anchor evidence differs/);
+  });
+
+  it('creates a deterministic receipt for a regenerated suffix', () => {
+    const plan = createAnchoredReplay(trace, 'e2');
+    const suffix: TraceEvent[] = [
+      { id: 'r3', step: 3, kind: 'repair', actor: 'coder', output: { patch: 'new' } },
+      { id: 'r4', step: 4, kind: 'verify', actor: 'tester', output: { status: 200 } },
+    ];
+
+    const first = finalizeAnchoredReplay(plan, trace.slice(0, 2), trace[2], suffix);
+    const second = finalizeAnchoredReplay(plan, trace.slice(0, 2), trace[2], structuredClone(suffix));
+
+    expect(first).toEqual(second);
+    expect(first.regeneratedSteps).toBe(2);
+    expect(first.regeneratedSuffixDigest).toBe(traceDigest(suffix));
+  });
+
+  it('rejects suffix events that cross the anchor boundary or reuse immutable ids', () => {
+    const plan = createAnchoredReplay(trace, 'e2');
+
+    expect(() =>
+      finalizeAnchoredReplay(plan, trace.slice(0, 2), trace[2], [
+        { id: 'r2', step: 2, kind: 'repair' },
+      ]),
+    ).toThrow(/at or before the anchor/);
+
+    expect(() =>
+      finalizeAnchoredReplay(plan, trace.slice(0, 2), trace[2], [
+        { id: 'e1', step: 3, kind: 'repair' },
+      ]),
+    ).toThrow(/reuses immutable event id/);
+  });
+
+  it('rejects duplicate ids, non-monotonic steps, and missing anchors', () => {
+    expect(() => createAnchoredReplay([trace[0], { ...trace[1], id: 'e0' }], 'e0')).toThrow(
+      /duplicate event id/,
+    );
+    expect(() => createAnchoredReplay([trace[1], trace[0]], 'e0')).toThrow(/strictly increasing/);
+    expect(() => createAnchoredReplay(trace, 'missing')).toThrow(/does not exist/);
+  });
+});

--- a/packages/witness/src/trace-replay.ts
+++ b/packages/witness/src/trace-replay.ts
@@ -52,6 +52,16 @@ export function canonicalJson(value: unknown): string {
     }
     if (Array.isArray(current)) {
       if (seen.has(current)) throw new Error('trace evidence contains a cycle');
+      const ownKeys = Reflect.ownKeys(current);
+      const expectedKeys = [...current.keys()].map(String);
+      expectedKeys.push('length');
+      if (
+        current.some((_, index) => !Object.hasOwn(current, index)) ||
+        ownKeys.length !== expectedKeys.length ||
+        ownKeys.some((key, index) => key !== expectedKeys[index])
+      ) {
+        throw new Error('trace evidence array must be dense and contain no extra properties');
+      }
       seen.add(current);
       const result = `[${current.map((item) => encode(item)).join(',')}]`;
       seen.delete(current);
@@ -59,9 +69,23 @@ export function canonicalJson(value: unknown): string {
     }
     if (typeof current === 'object') {
       const object = current as Record<string, unknown>;
+      const prototype = Object.getPrototypeOf(object);
+      if (prototype !== Object.prototype && prototype !== null) {
+        throw new Error('trace evidence object must be a plain JSON object');
+      }
       if (seen.has(object)) throw new Error('trace evidence contains a cycle');
+      const ownKeys = Reflect.ownKeys(object);
+      if (ownKeys.some((key) => typeof key !== 'string')) {
+        throw new Error('trace evidence object contains a symbol key');
+      }
+      for (const key of ownKeys as string[]) {
+        const descriptor = Object.getOwnPropertyDescriptor(object, key);
+        if (!descriptor?.enumerable || !('value' in descriptor)) {
+          throw new Error(`trace evidence property "${key}" must be an enumerable data property`);
+        }
+      }
       seen.add(object);
-      const entries = Object.keys(object)
+      const entries = (ownKeys as string[])
         .sort()
         .map((key) => {
           const item = object[key];

--- a/packages/witness/src/trace-replay.ts
+++ b/packages/witness/src/trace-replay.ts
@@ -1,0 +1,232 @@
+import { createHash } from 'node:crypto';
+
+export interface TraceEvent {
+  id: string;
+  step: number;
+  kind: string;
+  actor?: string;
+  input?: unknown;
+  output?: unknown;
+  metadata?: Record<string, unknown>;
+}
+
+export interface AnchoredTraceReplay {
+  version: 1;
+  anchorId: string;
+  anchorStep: number;
+  prefixLength: number;
+  prefixDigest: string;
+  anchorDigest: string;
+  originalSuffixDigest: string;
+  originalTraceDigest: string;
+}
+
+export interface ReplayReceipt {
+  version: 1;
+  anchorId: string;
+  prefixDigest: string;
+  anchorDigest: string;
+  regeneratedSuffixDigest: string;
+  combinedTraceDigest: string;
+  regeneratedSteps: number;
+}
+
+function sha256(value: string): string {
+  return createHash('sha256').update(value).digest('hex');
+}
+
+/**
+ * Deterministic JSON encoding for trace evidence. Unsupported values fail
+ * closed rather than silently changing the evidence being hashed.
+ */
+export function canonicalJson(value: unknown): string {
+  const seen = new WeakSet<object>();
+
+  const encode = (current: unknown): string => {
+    if (current === null) return 'null';
+    if (typeof current === 'string') return JSON.stringify(current);
+    if (typeof current === 'boolean') return current ? 'true' : 'false';
+    if (typeof current === 'number') {
+      if (!Number.isFinite(current)) throw new Error('trace evidence contains a non-finite number');
+      return JSON.stringify(Object.is(current, -0) ? 0 : current);
+    }
+    if (Array.isArray(current)) {
+      if (seen.has(current)) throw new Error('trace evidence contains a cycle');
+      seen.add(current);
+      const result = `[${current.map((item) => encode(item)).join(',')}]`;
+      seen.delete(current);
+      return result;
+    }
+    if (typeof current === 'object') {
+      const object = current as Record<string, unknown>;
+      if (seen.has(object)) throw new Error('trace evidence contains a cycle');
+      seen.add(object);
+      const entries = Object.keys(object)
+        .sort()
+        .map((key) => {
+          const item = object[key];
+          if (item === undefined) throw new Error(`trace evidence contains undefined at key "${key}"`);
+          return `${JSON.stringify(key)}:${encode(item)}`;
+        });
+      seen.delete(object);
+      return `{${entries.join(',')}}`;
+    }
+    throw new Error(`trace evidence contains unsupported type "${typeof current}"`);
+  };
+
+  return encode(value);
+}
+
+export function traceDigest(events: readonly TraceEvent[]): string {
+  validateTrace(events, { allowEmpty: true });
+  return sha256(canonicalJson(events));
+}
+
+/**
+ * Bind an intervention anchor to an immutable trace prefix. The original suffix
+ * digest is retained as evidence but is never replayed as candidate output.
+ */
+export function createAnchoredReplay(
+  events: readonly TraceEvent[],
+  anchorId: string,
+): AnchoredTraceReplay {
+  validateTrace(events);
+  const anchorIndex = events.findIndex((event) => event.id === anchorId);
+  if (anchorIndex < 0) throw new Error(`anchor "${anchorId}" does not exist in trace`);
+
+  const prefix = events.slice(0, anchorIndex);
+  const anchor = events[anchorIndex];
+  const suffix = events.slice(anchorIndex + 1);
+
+  return {
+    version: 1,
+    anchorId: anchor.id,
+    anchorStep: anchor.step,
+    prefixLength: prefix.length,
+    prefixDigest: traceDigest(prefix),
+    anchorDigest: sha256(canonicalJson(anchor)),
+    originalSuffixDigest: traceDigest(suffix),
+    originalTraceDigest: traceDigest(events),
+  };
+}
+
+/**
+ * Verify that replay reconstruction reached the intervention anchor from the
+ * exact same causal prefix. A digest match is necessary before regeneration.
+ */
+export function verifyReplayPrefix(
+  plan: AnchoredTraceReplay,
+  reconstructedPrefix: readonly TraceEvent[],
+): { ok: boolean; reason?: string } {
+  try {
+    validatePlan(plan);
+    validateTrace(reconstructedPrefix, { allowEmpty: true });
+  } catch (error) {
+    return { ok: false, reason: (error as Error).message };
+  }
+
+  if (reconstructedPrefix.length !== plan.prefixLength) {
+    return { ok: false, reason: 'reconstructed prefix length differs from anchored prefix' };
+  }
+  if (traceDigest(reconstructedPrefix) !== plan.prefixDigest) {
+    return { ok: false, reason: 'reconstructed prefix digest differs from anchored prefix' };
+  }
+  return { ok: true };
+}
+
+/**
+ * Produce a replay receipt only after an exact prefix check. The regenerated
+ * suffix must start strictly after the anchor and cannot reuse immutable ids.
+ */
+export function finalizeAnchoredReplay(
+  plan: AnchoredTraceReplay,
+  reconstructedPrefix: readonly TraceEvent[],
+  anchor: TraceEvent,
+  regeneratedSuffix: readonly TraceEvent[],
+): ReplayReceipt {
+  const prefix = verifyReplayPrefix(plan, reconstructedPrefix);
+  if (!prefix.ok) throw new Error(prefix.reason);
+  validatePlan(plan);
+  validateEvent(anchor);
+  validateTrace(regeneratedSuffix, { allowEmpty: true });
+
+  if (anchor.id !== plan.anchorId || anchor.step !== plan.anchorStep) {
+    throw new Error('anchor identity or step differs from replay plan');
+  }
+  if (sha256(canonicalJson(anchor)) !== plan.anchorDigest) {
+    throw new Error('anchor evidence differs from replay plan');
+  }
+
+  const immutableIds = new Set(reconstructedPrefix.map((event) => event.id));
+  immutableIds.add(anchor.id);
+  for (const event of regeneratedSuffix) {
+    if (event.step <= anchor.step) {
+      throw new Error('regenerated suffix contains an event at or before the anchor step');
+    }
+    if (immutableIds.has(event.id)) {
+      throw new Error(`regenerated suffix reuses immutable event id "${event.id}"`);
+    }
+  }
+
+  const combined = [...reconstructedPrefix, anchor, ...regeneratedSuffix];
+  validateTrace(combined);
+
+  return {
+    version: 1,
+    anchorId: plan.anchorId,
+    prefixDigest: plan.prefixDigest,
+    anchorDigest: plan.anchorDigest,
+    regeneratedSuffixDigest: traceDigest(regeneratedSuffix),
+    combinedTraceDigest: traceDigest(combined),
+    regeneratedSteps: regeneratedSuffix.length,
+  };
+}
+
+function validatePlan(plan: AnchoredTraceReplay): void {
+  if (plan.version !== 1) throw new Error('unsupported anchored replay version');
+  if (!plan.anchorId) throw new Error('replay plan is missing anchor id');
+  if (!Number.isInteger(plan.anchorStep) || plan.anchorStep < 0) {
+    throw new Error('replay plan anchor step must be a non-negative integer');
+  }
+  if (!Number.isInteger(plan.prefixLength) || plan.prefixLength < 0) {
+    throw new Error('replay plan prefix length must be a non-negative integer');
+  }
+  for (const [name, digest] of Object.entries({
+    prefixDigest: plan.prefixDigest,
+    anchorDigest: plan.anchorDigest,
+    originalSuffixDigest: plan.originalSuffixDigest,
+    originalTraceDigest: plan.originalTraceDigest,
+  })) {
+    if (!/^[0-9a-f]{64}$/.test(digest)) throw new Error(`${name} must be a sha256 hex digest`);
+  }
+}
+
+function validateEvent(event: TraceEvent): void {
+  if (!event || typeof event !== 'object') throw new Error('trace event must be an object');
+  if (!event.id || typeof event.id !== 'string') throw new Error('trace event id must be a non-empty string');
+  if (!Number.isInteger(event.step) || event.step < 0) {
+    throw new Error(`trace event "${event.id}" step must be a non-negative integer`);
+  }
+  if (!event.kind || typeof event.kind !== 'string') {
+    throw new Error(`trace event "${event.id}" kind must be a non-empty string`);
+  }
+  canonicalJson(event);
+}
+
+function validateTrace(
+  events: readonly TraceEvent[],
+  options: { allowEmpty?: boolean } = {},
+): void {
+  if (!Array.isArray(events)) throw new Error('trace must be an array');
+  if (events.length === 0 && !options.allowEmpty) throw new Error('trace must contain at least one event');
+
+  const ids = new Set<string>();
+  let previousStep = -1;
+  for (const event of events) {
+    validateEvent(event);
+    if (ids.has(event.id)) throw new Error(`trace contains duplicate event id "${event.id}"`);
+    if (event.step <= previousStep) throw new Error('trace steps must be strictly increasing');
+    ids.add(event.id);
+    previousStep = event.step;
+  }
+}


### PR DESCRIPTION
## Summary

Implements the infrastructure half of #41: a deterministic anchored trace replay primitive in `@dream-machine/witness` so repair experiments can prove they reconstructed the same causal prefix before regenerating a downstream suffix.

## What changed

* adds canonical JSON hashing for JSON-safe trace evidence
* adds `createAnchoredReplay`, `verifyReplayPrefix`, and `finalizeAnchoredReplay`
* binds prefix length/digest, exact anchor identity/evidence, original suffix digest, and original full-trace digest
* rejects unsupported evidence, duplicate ids, non-monotonic steps, moved or modified anchors, prefix mutation, suffix boundary crossing, and immutable id reuse
* exports the API from `@dream-machine/witness`
* adds deterministic adversarial tests
* adds ADR-0003 and updates the ADR index

## Security boundary

Trace digests prove evidence identity only. They grant no execution or promotion authority. RVM remains the authority boundary. No merge, deployment, credential change, or irreversible migration is performed by this PR.

## Research basis

SymTrace, arXiv:2608.25920, submitted 2026-08-26, reports that unguided whole-trajectory reruns have poor failure reproduction and repair rates. This PR does not claim to reproduce the paper's repair gains. It only adds the smaller reusable invariant needed to run a controlled RuV reproduction.

## Validation plan

Repository CI must pass build, typecheck, lint, existing witness tests, and the new replay tests. A separate MetaHarness reproduction should compare whole rerun, anchored no-intervention replay, and anchored symptom-driven intervention under identical model, seeds, tools, budgets, and evaluator.

## Rollback

Fully additive. Revert the module export, trace replay source/tests, and ADR. No stored-data migration or existing witness format changes.

Closes infrastructure portion of #41. Performance claims remain gated on independent reproduction.