### PR TITLE
feat(witness): claim relative evidence receipts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,9 @@ jobs:
       - run: npm ci
       - name: Typecheck + build
         run: npm run build
+      - name: ClaimReceipt production benchmark
+        if: matrix.node == 22
+        run: node scripts/bench-claim-receipt.mjs
       - name: Lint
         run: npm run lint
       - name: Test (with coverage)

--- a/docs/adrs/ADR-0003-claim-relative-evidence-receipts.md
+++ b/docs/adrs/ADR-0003-claim-relative-evidence-receipts.md
@@ -1,0 +1,121 @@
+# ADR 0003: Claim Relative Evidence Receipts
+
+Status: Proposed
+
+Date: 2026-09-03
+
+Issue: #70
+
+## Context
+
+Dream Machine already binds reports to source commits and uses durable ledgers, deterministic evaluators, witness receipts, and guarded candidate promotion. Those controls prove that retained artifacts have not changed, but they do not prove that the retained evidence is sufficient for a particular claim or that all assignments committed before an experiment are represented.
+
+This distinction matters for perpetual self improvement. A candidate can look supported if inconvenient assignments are omitted, terminal outcomes are missing, or private evidence needed for one claim is withheld while generic logs remain internally consistent.
+
+ClaimReceipt, arXiv:2609.01992, submitted 2026-09-02, formalizes these as separate questions: sufficiency and coverage. The originating team reports exact replay over 1,392 historical records and a prospective epoch where withholding one terminal receipt correctly yields an inconclusive coverage result. The same paper reports that its own frozen specification remains ambiguous to an independent reader. We therefore adopt the primitive, not the external specification as authority.
+
+## Decision
+
+Add a small deterministic claim relative verifier to `@dream-machine/witness`.
+
+The verifier consumes four inputs:
+
+1. An experiment manifest whose complete assignment universe was committed before outcomes were visible.
+2. An independently anchored SHA 256 digest of that manifest.
+3. A claim specification declaring required field groups, required private openings, and whether terminal coverage is mandatory.
+4. Typed evidence records containing opaque assignment identifiers, semantic field group identifiers, evidence digests, opening state, and terminal state.
+
+The verifier returns one of four states:
+
+`PASS` means the declared evidence requirements and committed assignment coverage are satisfied.
+
+`INVALID` means the evidence or commitment is structurally inconsistent, malformed, duplicated, undeclared, or does not match the independently anchored manifest digest.
+
+`INCONCLUSIVE_COVERAGE` means at least one committed assignment lacks terminal evidence when terminal coverage is required.
+
+`INCONCLUSIVE_SUFFICIENCY` means assignment coverage is adequate but evidence required for the specific claim is missing or unavailable to the verifier.
+
+A `PASS` receipt does not establish that the scientific claim is true. It establishes only that the verifier received the evidence that the predeclared claim says is necessary.
+
+Every verification result carries `authority: none`. Evidence identity, statistical confidence, and claim sufficiency do not grant execution rights. RVM remains authoritative for privileged effects.
+
+## Canonicalization
+
+Manifest assignment order is not semantically meaningful. Assignment identifiers are validated, sorted, and hashed with the experiment identifier, protocol version, and canonical ISO 8601 commitment timestamp.
+
+Claim requirements are validated, deduplicated, sorted, and hashed independently. A field requiring a private opening must also be a required field.
+
+Evidence identities are the pair `(assignmentId, fieldGroup)`. Duplicate identities are invalid rather than resolved by first or last writer semantics. Evidence records are sorted before hashing. Digests must be 64 character lowercase SHA 256 hex strings.
+
+## Trust boundary
+
+The expected manifest digest must come from an independent commitment, for example an RVF artifact, RVM anchored policy object, signed external manifest, or append only witness store. If the caller can rewrite both the manifest and the expected digest, omission remains possible.
+
+The receipt intentionally excludes raw prompts, model outputs, private openings, or customer data. It stores opaque identifiers, digests, and verification state.
+
+## Resource bounds
+
+The initial implementation accepts at most 10,000 assignments and 100,000 evidence records per verification call. These bounds prevent an untrusted evaluator payload from turning a governance check into unbounded memory consumption.
+
+## Integration
+
+Dream Machine uses the receipt before treating an experiment as promotion evidence.
+
+MetaHarness independently constructs and attacks manifests and evidence sets.
+
+Core Memory may store receipt metadata and experiment lineage, but not convert receipt status into authority.
+
+RVF can package signed manifests and claim specifications.
+
+RVM can anchor expected manifest digests and enforce that a verifier cannot rewrite its own commitment.
+
+RuVector can index receipts for audit and retrieval while preserving the immutable evidence roots.
+
+## Benchmark protocol
+
+The first benchmark compares generic log presence checks with claim relative verification.
+
+The workload must include complete evidence plus attacks covering omitted terminal assignments, omitted required field groups, withheld openings, undeclared assignments, duplicate evidence identities, malformed digests, rewritten manifests, reordered equivalent manifests, and resource exhaustion.
+
+Report:
+
+1. Baseline and candidate commit SHAs.
+2. Node, TypeScript, and Vitest versions.
+3. CPU and operating system.
+4. Sample size and fixed seed where randomized cases are added.
+5. False PASS rate.
+6. False INVALID or false inconclusive rate on benign inputs.
+7. Median and p95 verification latency.
+8. Peak process memory delta.
+9. Evidence record count and bytes represented.
+10. Every failing or unexpected case.
+11. Exact reproduction command.
+
+The production gate is zero false PASS across the declared omission and mutation suite, deterministic replay, no authority expansion, and p95 local verification below 1 ms at 1,000 assignments on a current desktop CPU.
+
+## Security review
+
+Adversarial cases must include:
+
+1. Recompute a digest after deleting an assignment while leaving the independently anchored expected digest unchanged.
+2. Insert evidence from an undeclared assignment.
+3. Duplicate an evidence identity with conflicting contents.
+4. Mark unrelated evidence terminal to try to cover a missing assignment.
+5. Withhold all private openings while preserving public evidence.
+6. Supply noncanonical timestamps and identifiers.
+7. Attempt maximum assignment and record counts.
+8. Verify that every output has `authority: none`.
+
+## Rollback
+
+The change is additive. Removing `claim-receipt.ts`, its tests, this ADR, and the export restores previous behavior. No stored data migration is required. Existing witness stamps remain byte compatible.
+
+## Consequences
+
+Positive: omissions become explicit against a committed experiment universe; evidence requirements become claim specific; private evidence can remain unopened unless a claim actually needs it; the primitive is reusable across self improvement, model routing, distributed experiments, and customer audits.
+
+Negative: the verifier cannot decide whether the chosen assignment universe or field groups are scientifically adequate. It can faithfully verify a poorly designed experiment. Independent evaluator design, hidden holdouts, persistent statistical validity, and human review remain necessary.
+
+## Promotion rule
+
+Do not merge solely because unit tests pass. Independent MetaHarness reproduction, repository CI, dependency review, CodeQL, and the declared latency and omission benchmark must all have resolved results. No autonomous merge.

--- a/docs/adrs/ADR-0007-claim-relative-evidence-receipts.md
+++ b/docs/adrs/ADR-0007-claim-relative-evidence-receipts.md
@@ -1,4 +1,4 @@
-# ADR 0003: Claim Relative Evidence Receipts
+# ADR 0007: Claim Relative Evidence Receipts
 
 Status: Proposed
 

--- a/docs/adrs/INDEX.md
+++ b/docs/adrs/INDEX.md
@@ -10,6 +10,7 @@ Alternatives Considered → Test Contract → References.
 | [ADR-0001](./ADR-0001-dream-machine-engine.md) | The Dream Machine engine — a config-driven, evidence-gated nightly evolution loop composed from the ruvnet stack | Accepted (v0.1.0 shipped) |
 | [ADR-0002](./ADR-0002-dream-cycle-security-adversarial-entrypoint-liveness.md) | Evaluator entrypoints must be classified live/blocked/suspicious-silent before an EVALUATED verdict is recorded | Proposed |
 | [ADR-0005](./ADR-0005-failure-attribution-before-mutation.md) | Attribute failure before mutation | Proposed |
+| [ADR-0003](./ADR-0003-claim-relative-evidence-receipts.md) | Claim-relative evidence receipts bind sufficiency and committed experiment coverage without granting authority | Proposed |
 
 ## How to amend
 

--- a/docs/adrs/INDEX.md
+++ b/docs/adrs/INDEX.md
@@ -10,6 +10,7 @@ Alternatives Considered → Test Contract → References.
 | [ADR-0001](./ADR-0001-dream-machine-engine.md) | The Dream Machine engine — a config-driven, evidence-gated nightly evolution loop composed from the ruvnet stack | Accepted (v0.1.0 shipped) |
 | [ADR-0002](./ADR-0002-dream-cycle-security-adversarial-entrypoint-liveness.md) | Evaluator entrypoints must be classified live/blocked/suspicious-silent before an EVALUATED verdict is recorded | Proposed |
 | [ADR-0005](./ADR-0005-failure-attribution-before-mutation.md) | Attribute failure before mutation | Proposed |
+| [ADR-0006](./ADR-0006-root-cause-security-patch-evaluation.md) | Root cause security patch evaluation | Proposed |
 | [ADR-0007](./ADR-0007-claim-relative-evidence-receipts.md) | Claim-relative evidence receipts bind sufficiency and committed experiment coverage without granting authority | Proposed |
 
 ## How to amend

--- a/docs/adrs/INDEX.md
+++ b/docs/adrs/INDEX.md
@@ -10,7 +10,7 @@ Alternatives Considered → Test Contract → References.
 | [ADR-0001](./ADR-0001-dream-machine-engine.md) | The Dream Machine engine — a config-driven, evidence-gated nightly evolution loop composed from the ruvnet stack | Accepted (v0.1.0 shipped) |
 | [ADR-0002](./ADR-0002-dream-cycle-security-adversarial-entrypoint-liveness.md) | Evaluator entrypoints must be classified live/blocked/suspicious-silent before an EVALUATED verdict is recorded | Proposed |
 | [ADR-0005](./ADR-0005-failure-attribution-before-mutation.md) | Attribute failure before mutation | Proposed |
-| [ADR-0003](./ADR-0003-claim-relative-evidence-receipts.md) | Claim-relative evidence receipts bind sufficiency and committed experiment coverage without granting authority | Proposed |
+| [ADR-0007](./ADR-0007-claim-relative-evidence-receipts.md) | Claim-relative evidence receipts bind sufficiency and committed experiment coverage without granting authority | Proposed |
 
 ## How to amend
 

--- a/packages/witness/src/claim-receipt.bench.test.ts
+++ b/packages/witness/src/claim-receipt.bench.test.ts
@@ -1,0 +1,185 @@
+import { arch, cpus, platform } from 'node:os';
+import { performance } from 'node:perf_hooks';
+import { createHash } from 'node:crypto';
+import { describe, expect, it } from 'vitest';
+import {
+  hashExperimentManifest,
+  verifyClaimEvidence,
+  type ClaimSpec,
+  type EvidenceRecord,
+  type ExperimentManifest,
+} from './claim-receipt.js';
+
+const SAMPLE_SIZE = 1_000;
+const WARMUP_RUNS = 10;
+const MEASURED_RUNS = 40;
+const SEED = 'claim-receipt-bench-v1';
+
+function digest(value: string): string {
+  return createHash('sha256').update(value).digest('hex');
+}
+
+function percentile(values: number[], fraction: number): number {
+  const ordered = [...values].sort((left, right) => left - right);
+  const index = Math.min(ordered.length - 1, Math.floor(ordered.length * fraction));
+  return ordered[index]!;
+}
+
+function genericAssignmentPresence(
+  manifest: ExperimentManifest,
+  records: readonly EvidenceRecord[],
+): boolean {
+  const present = new Set(records.map((record) => record.assignmentId));
+  return manifest.assignments.every((assignment) => present.has(assignment.id));
+}
+
+function fixture(): {
+  manifest: ExperimentManifest;
+  claim: ClaimSpec;
+  evidence: EvidenceRecord[];
+  manifestDigest: string;
+} {
+  const assignments = Array.from({ length: SAMPLE_SIZE }, (_, index) => ({
+    id: `a-${String(index).padStart(4, '0')}`,
+  }));
+  const manifest: ExperimentManifest = {
+    experimentId: 'claim-receipt-scale',
+    protocolVersion: 'cr-ruv-1',
+    committedAt: '2026-09-03T12:00:00.000Z',
+    assignments,
+  };
+  const claim: ClaimSpec = {
+    claimId: 'quality-and-cost',
+    requiredFieldGroups: ['outcome', 'cost'],
+    requireOpenedFieldGroups: ['outcome'],
+  };
+  const evidence: EvidenceRecord[] = assignments.flatMap(({ id }) => [
+    {
+      assignmentId: id,
+      fieldGroup: 'outcome',
+      digest: digest(`${SEED}:${id}:outcome`),
+      opened: true,
+      terminal: true,
+    },
+    {
+      assignmentId: id,
+      fieldGroup: 'cost',
+      digest: digest(`${SEED}:${id}:cost`),
+      opened: false,
+      terminal: false,
+    },
+  ]);
+  return { manifest, claim, evidence, manifestDigest: hashExperimentManifest(manifest) };
+}
+
+describe('claim receipt deterministic benchmark', () => {
+  it('reports scale latency and catches faults generic assignment presence misses', () => {
+    const { manifest, claim, evidence, manifestDigest } = fixture();
+    const beforeHeap = process.memoryUsage().heapUsed;
+
+    for (let index = 0; index < WARMUP_RUNS; index += 1) {
+      expect(verifyClaimEvidence(manifest, manifestDigest, claim, evidence).status).toBe('PASS');
+      expect(genericAssignmentPresence(manifest, evidence)).toBe(true);
+    }
+
+    const candidateMs: number[] = [];
+    const baselineMs: number[] = [];
+    for (let index = 0; index < MEASURED_RUNS; index += 1) {
+      let started = performance.now();
+      const candidate = verifyClaimEvidence(manifest, manifestDigest, claim, evidence);
+      candidateMs.push(performance.now() - started);
+      expect(candidate.status).toBe('PASS');
+
+      started = performance.now();
+      expect(genericAssignmentPresence(manifest, evidence)).toBe(true);
+      baselineMs.push(performance.now() - started);
+    }
+
+    const targetId = manifest.assignments[Math.floor(SAMPLE_SIZE / 2)]!.id;
+    const findRecord = (fieldGroup: string): number =>
+      evidence.findIndex(
+        (record) => record.assignmentId === targetId && record.fieldGroup === fieldGroup,
+      );
+    const outcomeIndex = findRecord('outcome');
+    const costIndex = findRecord('cost');
+    expect(outcomeIndex).toBeGreaterThanOrEqual(0);
+    expect(costIndex).toBeGreaterThanOrEqual(0);
+
+    const missingTerminal = evidence.map((record, index) =>
+      index === outcomeIndex ? { ...record, terminal: false } : record,
+    );
+    const missingField = evidence.filter((_, index) => index !== costIndex);
+    const withheldOpening = evidence.map((record, index) =>
+      index === outcomeIndex ? { ...record, opened: false } : record,
+    );
+    const malformedDigest = evidence.map((record, index) =>
+      index === outcomeIndex ? { ...record, digest: 'deadbeef' } : record,
+    );
+    const undeclared = [
+      ...evidence,
+      {
+        assignmentId: 'a-extra',
+        fieldGroup: 'outcome',
+        digest: digest('undeclared'),
+        opened: true,
+        terminal: true,
+      },
+    ];
+    const rewrittenManifest: ExperimentManifest = {
+      ...manifest,
+      assignments: manifest.assignments.slice(0, SAMPLE_SIZE - 1),
+    };
+
+    const attacks = [
+      { manifest, evidence: missingTerminal },
+      { manifest, evidence: missingField },
+      { manifest, evidence: withheldOpening },
+      { manifest, evidence: malformedDigest },
+      { manifest, evidence: undeclared },
+      { manifest: rewrittenManifest, evidence },
+    ];
+    let genericFalsePasses = 0;
+    let candidateFalsePasses = 0;
+    for (const attack of attacks) {
+      if (genericAssignmentPresence(attack.manifest, attack.evidence)) genericFalsePasses += 1;
+      if (
+        verifyClaimEvidence(attack.manifest, manifestDigest, claim, attack.evidence).status ===
+        'PASS'
+      ) {
+        candidateFalsePasses += 1;
+      }
+    }
+
+    const afterHeap = process.memoryUsage().heapUsed;
+    const report = {
+      benchmark: SEED,
+      sampleSize: SAMPLE_SIZE,
+      evidenceRecords: evidence.length,
+      warmupRuns: WARMUP_RUNS,
+      measuredRuns: MEASURED_RUNS,
+      environment: {
+        node: process.version,
+        platform: platform(),
+        arch: arch(),
+        cpu: cpus()[0]?.model ?? 'unknown',
+      },
+      genericPresence: {
+        p50Ms: percentile(baselineMs, 0.5),
+        p95Ms: percentile(baselineMs, 0.95),
+        falsePasses: genericFalsePasses,
+        attacks: attacks.length,
+      },
+      claimReceipt: {
+        p50Ms: percentile(candidateMs, 0.5),
+        p95Ms: percentile(candidateMs, 0.95),
+        falsePasses: candidateFalsePasses,
+        attacks: attacks.length,
+      },
+      heapDeltaBytes: afterHeap - beforeHeap,
+    };
+
+    console.log(`CLAIM_RECEIPT_BENCH ${JSON.stringify(report)}`);
+    expect(genericFalsePasses).toBeGreaterThan(0);
+    expect(candidateFalsePasses).toBe(0);
+  });
+});

--- a/packages/witness/src/claim-receipt.test.ts
+++ b/packages/witness/src/claim-receipt.test.ts
@@ -1,0 +1,145 @@
+import { createHash } from 'node:crypto';
+import { describe, expect, it } from 'vitest';
+import {
+  hashExperimentManifest,
+  verifyClaimEvidence,
+  type ClaimSpec,
+  type EvidenceRecord,
+  type ExperimentManifest,
+} from './claim-receipt.js';
+
+function digest(value: string): string {
+  return createHash('sha256').update(value).digest('hex');
+}
+
+const MANIFEST: ExperimentManifest = {
+  experimentId: 'claim-receipt-repro',
+  protocolVersion: 'cr-ruv-1',
+  committedAt: '2026-09-03T12:00:00.000Z',
+  assignments: [{ id: 'a-1' }, { id: 'a-2' }],
+};
+
+const CLAIM: ClaimSpec = {
+  claimId: 'quality-improved',
+  requiredFieldGroups: ['outcome', 'cost'],
+  requireOpenedFieldGroups: ['outcome'],
+};
+
+function completeEvidence(): EvidenceRecord[] {
+  return [
+    { assignmentId: 'a-1', fieldGroup: 'outcome', digest: digest('a1-outcome'), opened: true, terminal: true },
+    { assignmentId: 'a-1', fieldGroup: 'cost', digest: digest('a1-cost'), opened: false, terminal: false },
+    { assignmentId: 'a-2', fieldGroup: 'outcome', digest: digest('a2-outcome'), opened: true, terminal: true },
+    { assignmentId: 'a-2', fieldGroup: 'cost', digest: digest('a2-cost'), opened: false, terminal: false },
+  ];
+}
+
+describe('claim-relative evidence receipts', () => {
+  it('passes complete claim-sufficient evidence and never carries authority', () => {
+    const expected = hashExperimentManifest(MANIFEST);
+    const receipt = verifyClaimEvidence(MANIFEST, expected, CLAIM, completeEvidence());
+    expect(receipt.status).toBe('PASS');
+    expect(receipt.authority).toBe('none');
+    expect(receipt.evidenceDigest).toMatch(/^[0-9a-f]{64}$/);
+  });
+
+  it('normalizes assignment ordering in the committed manifest digest', () => {
+    const reordered: ExperimentManifest = {
+      ...MANIFEST,
+      assignments: [...MANIFEST.assignments].reverse(),
+    };
+    expect(hashExperimentManifest(reordered)).toBe(hashExperimentManifest(MANIFEST));
+  });
+
+  it('returns INCONCLUSIVE_COVERAGE when one committed assignment lacks terminal evidence', () => {
+    const records = completeEvidence();
+    records[2] = { ...records[2]!, terminal: false };
+    const receipt = verifyClaimEvidence(MANIFEST, hashExperimentManifest(MANIFEST), CLAIM, records);
+    expect(receipt.status).toBe('INCONCLUSIVE_COVERAGE');
+    expect(receipt.missingTerminalAssignments).toEqual(['a-2']);
+  });
+
+  it('returns INCONCLUSIVE_SUFFICIENCY when a claim-required field is omitted', () => {
+    const records = completeEvidence().filter(
+      (record) => !(record.assignmentId === 'a-2' && record.fieldGroup === 'cost'),
+    );
+    const receipt = verifyClaimEvidence(MANIFEST, hashExperimentManifest(MANIFEST), CLAIM, records);
+    expect(receipt.status).toBe('INCONCLUSIVE_SUFFICIENCY');
+    expect(receipt.missingFields).toEqual(['a-2/cost']);
+  });
+
+  it('returns INCONCLUSIVE_SUFFICIENCY when a required private opening is withheld', () => {
+    const records = completeEvidence();
+    records[0] = { ...records[0]!, opened: false };
+    const receipt = verifyClaimEvidence(MANIFEST, hashExperimentManifest(MANIFEST), CLAIM, records);
+    expect(receipt.status).toBe('INCONCLUSIVE_SUFFICIENCY');
+    expect(receipt.missingOpenings).toEqual(['a-1/outcome']);
+  });
+
+  it('invalidates evidence for an assignment outside the committed universe', () => {
+    const records = completeEvidence();
+    records.push({
+      assignmentId: 'a-3',
+      fieldGroup: 'outcome',
+      digest: digest('undeclared'),
+      opened: true,
+      terminal: true,
+    });
+    const receipt = verifyClaimEvidence(MANIFEST, hashExperimentManifest(MANIFEST), CLAIM, records);
+    expect(receipt.status).toBe('INVALID');
+    expect(receipt.reason).toMatch(/undeclared assignment/);
+  });
+
+  it('invalidates duplicate evidence identities rather than selecting one', () => {
+    const records = completeEvidence();
+    records.push({ ...records[0]! });
+    const receipt = verifyClaimEvidence(MANIFEST, hashExperimentManifest(MANIFEST), CLAIM, records);
+    expect(receipt.status).toBe('INVALID');
+    expect(receipt.reason).toMatch(/duplicate evidence identity/);
+  });
+
+  it('invalidates a rewritten manifest when the independently anchored digest is unchanged', () => {
+    const expected = hashExperimentManifest(MANIFEST);
+    const rewritten: ExperimentManifest = {
+      ...MANIFEST,
+      assignments: [{ id: 'a-1' }],
+    };
+    const receipt = verifyClaimEvidence(rewritten, expected, CLAIM, completeEvidence().slice(0, 2));
+    expect(receipt.status).toBe('INVALID');
+    expect(receipt.reason).toMatch(/manifest digest mismatch/);
+  });
+
+  it('invalidates malformed evidence digests', () => {
+    const records = completeEvidence();
+    records[0] = { ...records[0]!, digest: 'deadbeef' };
+    const receipt = verifyClaimEvidence(MANIFEST, hashExperimentManifest(MANIFEST), CLAIM, records);
+    expect(receipt.status).toBe('INVALID');
+    expect(receipt.reason).toMatch(/64 lowercase hex/);
+  });
+
+  it('invalidates a claim that asks to open a field it did not require', () => {
+    const invalidClaim: ClaimSpec = {
+      claimId: 'bad-claim',
+      requiredFieldGroups: ['outcome'],
+      requireOpenedFieldGroups: ['cost'],
+    };
+    const receipt = verifyClaimEvidence(
+      MANIFEST,
+      hashExperimentManifest(MANIFEST),
+      invalidClaim,
+      completeEvidence(),
+    );
+    expect(receipt.status).toBe('INVALID');
+    expect(receipt.reason).toMatch(/must also be required/);
+  });
+
+  it('invalidates noncanonical manifest timestamps', () => {
+    const noncanonical: ExperimentManifest = {
+      ...MANIFEST,
+      committedAt: '2026-09-03T12:00:00Z',
+    };
+    const receipt = verifyClaimEvidence(noncanonical, '0'.repeat(64), CLAIM, completeEvidence());
+    expect(receipt.status).toBe('INVALID');
+    expect(receipt.reason).toMatch(/canonical ISO-8601/);
+  });
+});

--- a/packages/witness/src/claim-receipt.ts
+++ b/packages/witness/src/claim-receipt.ts
@@ -1,0 +1,357 @@
+import { createHash } from 'node:crypto';
+
+/** Maximum assignments accepted by a single committed experiment manifest. */
+export const MAX_CLAIM_RECEIPT_ASSIGNMENTS = 10_000;
+/** Maximum evidence records accepted by a single verification call. */
+export const MAX_CLAIM_RECEIPT_RECORDS = 100_000;
+
+/** A member of the experiment universe committed before outcomes are observed. */
+export interface ExperimentAssignment {
+  /** Stable opaque assignment identifier. */
+  id: string;
+}
+
+/** The immutable experiment universe against which omissions are evaluated. */
+export interface ExperimentManifest {
+  /** Stable experiment family identifier. */
+  experimentId: string;
+  /** Version of the protocol/evaluator contract used for this experiment. */
+  protocolVersion: string;
+  /** Canonical ISO-8601 timestamp recorded before candidate outcomes are visible. */
+  committedAt: string;
+  /** Complete set of committed assignments. Order is not semantically meaningful. */
+  assignments: readonly ExperimentAssignment[];
+}
+
+/** One retained piece of typed evidence. Raw private evidence is intentionally excluded. */
+export interface EvidenceRecord {
+  /** Assignment this evidence belongs to. */
+  assignmentId: string;
+  /** Claim-visible semantic field group, for example `outcome` or `cost`. */
+  fieldGroup: string;
+  /** SHA-256 digest of the retained evidence bytes. */
+  digest: string;
+  /** Whether an auditor-visible opening for this record is available. */
+  opened: boolean;
+  /** Whether this record proves terminal completion for the assignment. */
+  terminal: boolean;
+}
+
+/** Evidence requirements for one inferential or accounting claim. */
+export interface ClaimSpec {
+  /** Stable claim identifier. */
+  claimId: string;
+  /** Field groups that must exist for every committed assignment. */
+  requiredFieldGroups: readonly string[];
+  /** Required groups whose private evidence must additionally be opened. */
+  requireOpenedFieldGroups?: readonly string[];
+  /** Whether every committed assignment requires terminal evidence. Default true. */
+  requireTerminalCoverage?: boolean;
+}
+
+/** Claim-relative verifier result. */
+export type ClaimStatus =
+  | 'PASS'
+  | 'INVALID'
+  | 'INCONCLUSIVE_COVERAGE'
+  | 'INCONCLUSIVE_SUFFICIENCY';
+
+/** Deterministic verification receipt. This receipt carries evidence, never authority. */
+export interface ClaimVerification {
+  /** Claim-relative verifier status. */
+  status: ClaimStatus;
+  /** Explicit reminder that this object cannot authorize execution. */
+  authority: 'none';
+  /** Canonical digest of the committed experiment universe. */
+  manifestDigest: string;
+  /** Canonical digest of the claim requirements. */
+  claimDigest: string;
+  /** Canonical digest of the supplied evidence records. Empty only for malformed evidence. */
+  evidenceDigest: string;
+  /** Committed assignments missing terminal evidence. */
+  missingTerminalAssignments: string[];
+  /** Required assignment/field pairs that are absent. */
+  missingFields: string[];
+  /** Required assignment/field pairs whose private evidence was not opened. */
+  missingOpenings: string[];
+  /** Human-readable reason for INVALID or INCONCLUSIVE results. */
+  reason?: string;
+}
+
+const HEX64 = /^[0-9a-f]{64}$/;
+const SAFE_ID = /^[A-Za-z0-9][A-Za-z0-9._:/@]{0,255}$/;
+
+function sha256Hex(input: string): string {
+  return createHash('sha256').update(input).digest('hex');
+}
+
+function validateId(value: string, name: string): void {
+  if (!SAFE_ID.test(value)) {
+    throw new Error(`${name} must be 1-256 safe identifier characters`);
+  }
+}
+
+function canonicalTimestamp(value: string): string {
+  const parsed = Date.parse(value);
+  if (!Number.isFinite(parsed)) {
+    throw new Error('committedAt must be a valid ISO-8601 timestamp');
+  }
+  const canonical = new Date(parsed).toISOString();
+  if (canonical !== value) {
+    throw new Error(`committedAt must be canonical ISO-8601, expected ${canonical}`);
+  }
+  return canonical;
+}
+
+function uniqueSorted(values: readonly string[], name: string): string[] {
+  const seen = new Set<string>();
+  const out: string[] = [];
+  for (const value of values) {
+    validateId(value, name);
+    if (seen.has(value)) {
+      throw new Error(`${name} contains duplicate ${value}`);
+    }
+    seen.add(value);
+    out.push(value);
+  }
+  return out.sort();
+}
+
+/**
+ * Compute the canonical manifest digest.
+ *
+ * Assignment order is normalized so equivalent committed universes hash identically.
+ */
+export function hashExperimentManifest(manifest: ExperimentManifest): string {
+  validateId(manifest.experimentId, 'experimentId');
+  validateId(manifest.protocolVersion, 'protocolVersion');
+  canonicalTimestamp(manifest.committedAt);
+  if (manifest.assignments.length === 0) {
+    throw new Error('manifest must contain at least one assignment');
+  }
+  if (manifest.assignments.length > MAX_CLAIM_RECEIPT_ASSIGNMENTS) {
+    throw new Error(`manifest exceeds ${MAX_CLAIM_RECEIPT_ASSIGNMENTS} assignments`);
+  }
+  const assignmentIds = uniqueSorted(
+    manifest.assignments.map((assignment) => assignment.id),
+    'assignment id',
+  );
+  return sha256Hex(
+    JSON.stringify({
+      experimentId: manifest.experimentId,
+      protocolVersion: manifest.protocolVersion,
+      committedAt: manifest.committedAt,
+      assignmentIds,
+    }),
+  );
+}
+
+/** Compute a canonical digest of claim requirements. */
+export function hashClaimSpec(claim: ClaimSpec): string {
+  validateId(claim.claimId, 'claimId');
+  const requiredFieldGroups = uniqueSorted(claim.requiredFieldGroups, 'requiredFieldGroups');
+  if (requiredFieldGroups.length === 0) {
+    throw new Error('claim must require at least one field group');
+  }
+  const requireOpenedFieldGroups = uniqueSorted(
+    claim.requireOpenedFieldGroups ?? [],
+    'requireOpenedFieldGroups',
+  );
+  for (const field of requireOpenedFieldGroups) {
+    if (!requiredFieldGroups.includes(field)) {
+      throw new Error(`opened field ${field} must also be required`);
+    }
+  }
+  return sha256Hex(
+    JSON.stringify({
+      claimId: claim.claimId,
+      requiredFieldGroups,
+      requireOpenedFieldGroups,
+      requireTerminalCoverage: claim.requireTerminalCoverage ?? true,
+    }),
+  );
+}
+
+interface CanonicalEvidence {
+  assignmentId: string;
+  fieldGroup: string;
+  digest: string;
+  opened: boolean;
+  terminal: boolean;
+}
+
+function canonicalizeEvidence(
+  records: readonly EvidenceRecord[],
+  assignments: ReadonlySet<string>,
+): CanonicalEvidence[] {
+  if (records.length > MAX_CLAIM_RECEIPT_RECORDS) {
+    throw new Error(`evidence exceeds ${MAX_CLAIM_RECEIPT_RECORDS} records`);
+  }
+  const seen = new Set<string>();
+  const canonical: CanonicalEvidence[] = [];
+  for (const record of records) {
+    validateId(record.assignmentId, 'evidence assignmentId');
+    validateId(record.fieldGroup, 'evidence fieldGroup');
+    if (!assignments.has(record.assignmentId)) {
+      throw new Error(`evidence references undeclared assignment ${record.assignmentId}`);
+    }
+    if (!HEX64.test(record.digest)) {
+      throw new Error('evidence digest must be 64 lowercase hex characters');
+    }
+    const key = `${record.assignmentId}\u0000${record.fieldGroup}`;
+    if (seen.has(key)) {
+      throw new Error(`duplicate evidence identity ${record.assignmentId}/${record.fieldGroup}`);
+    }
+    seen.add(key);
+    canonical.push({
+      assignmentId: record.assignmentId,
+      fieldGroup: record.fieldGroup,
+      digest: record.digest,
+      opened: record.opened,
+      terminal: record.terminal,
+    });
+  }
+  canonical.sort((a, b) =>
+    a.assignmentId === b.assignmentId
+      ? a.fieldGroup.localeCompare(b.fieldGroup)
+      : a.assignmentId.localeCompare(b.assignmentId),
+  );
+  return canonical;
+}
+
+/** Compute a canonical digest over supplied evidence records. */
+export function hashEvidenceRecords(
+  manifest: ExperimentManifest,
+  records: readonly EvidenceRecord[],
+): string {
+  const assignmentIds = new Set(manifest.assignments.map((assignment) => assignment.id));
+  const canonical = canonicalizeEvidence(records, assignmentIds);
+  return sha256Hex(JSON.stringify(canonical));
+}
+
+function invalidReceipt(
+  manifestDigest: string,
+  claimDigest: string,
+  reason: string,
+): ClaimVerification {
+  return {
+    status: 'INVALID',
+    authority: 'none',
+    manifestDigest,
+    claimDigest,
+    evidenceDigest: '',
+    missingTerminalAssignments: [],
+    missingFields: [],
+    missingOpenings: [],
+    reason,
+  };
+}
+
+/**
+ * Verify whether retained evidence is complete enough for one declared claim.
+ *
+ * `PASS` means only that the declared evidence is present and bound to the committed
+ * assignment universe. It does not establish that the scientific claim is true.
+ *
+ * The expected manifest digest must come from an independently anchored commitment.
+ * A caller that can freely rewrite both the manifest and its expected digest can still
+ * launder omissions; that trust boundary belongs to RVM/RVF or an external signer.
+ */
+export function verifyClaimEvidence(
+  manifest: ExperimentManifest,
+  expectedManifestDigest: string,
+  claim: ClaimSpec,
+  records: readonly EvidenceRecord[],
+): ClaimVerification {
+  let manifestDigest = '';
+  let claimDigest = '';
+  try {
+    manifestDigest = hashExperimentManifest(manifest);
+    claimDigest = hashClaimSpec(claim);
+  } catch (error) {
+    return invalidReceipt(manifestDigest, claimDigest, (error as Error).message);
+  }
+
+  if (!HEX64.test(expectedManifestDigest)) {
+    return invalidReceipt(manifestDigest, claimDigest, 'expected manifest digest is malformed');
+  }
+  if (manifestDigest !== expectedManifestDigest) {
+    return invalidReceipt(manifestDigest, claimDigest, 'manifest digest mismatch');
+  }
+
+  const assignmentIds = manifest.assignments.map((assignment) => assignment.id).sort();
+  let canonicalEvidence: CanonicalEvidence[];
+  try {
+    canonicalEvidence = canonicalizeEvidence(records, new Set(assignmentIds));
+  } catch (error) {
+    return invalidReceipt(manifestDigest, claimDigest, (error as Error).message);
+  }
+  const evidenceDigest = sha256Hex(JSON.stringify(canonicalEvidence));
+  const byIdentity = new Map(
+    canonicalEvidence.map((record) => [`${record.assignmentId}\u0000${record.fieldGroup}`, record]),
+  );
+
+  const terminalAssignments = new Set(
+    canonicalEvidence.filter((record) => record.terminal).map((record) => record.assignmentId),
+  );
+  const requireTerminalCoverage = claim.requireTerminalCoverage ?? true;
+  const missingTerminalAssignments = requireTerminalCoverage
+    ? assignmentIds.filter((assignmentId) => !terminalAssignments.has(assignmentId))
+    : [];
+
+  if (missingTerminalAssignments.length > 0) {
+    return {
+      status: 'INCONCLUSIVE_COVERAGE',
+      authority: 'none',
+      manifestDigest,
+      claimDigest,
+      evidenceDigest,
+      missingTerminalAssignments,
+      missingFields: [],
+      missingOpenings: [],
+      reason: 'one or more committed assignments lack terminal evidence',
+    };
+  }
+
+  const requiredFields = [...claim.requiredFieldGroups].sort();
+  const openedFields = new Set(claim.requireOpenedFieldGroups ?? []);
+  const missingFields: string[] = [];
+  const missingOpenings: string[] = [];
+
+  for (const assignmentId of assignmentIds) {
+    for (const fieldGroup of requiredFields) {
+      const record = byIdentity.get(`${assignmentId}\u0000${fieldGroup}`);
+      const identity = `${assignmentId}/${fieldGroup}`;
+      if (!record) {
+        missingFields.push(identity);
+      } else if (openedFields.has(fieldGroup) && !record.opened) {
+        missingOpenings.push(identity);
+      }
+    }
+  }
+
+  if (missingFields.length > 0 || missingOpenings.length > 0) {
+    return {
+      status: 'INCONCLUSIVE_SUFFICIENCY',
+      authority: 'none',
+      manifestDigest,
+      claimDigest,
+      evidenceDigest,
+      missingTerminalAssignments: [],
+      missingFields,
+      missingOpenings,
+      reason: 'retained evidence is insufficient for the declared claim',
+    };
+  }
+
+  return {
+    status: 'PASS',
+    authority: 'none',
+    manifestDigest,
+    claimDigest,
+    evidenceDigest,
+    missingTerminalAssignments: [],
+    missingFields: [],
+    missingOpenings: [],
+  };
+}

--- a/packages/witness/src/claim-receipt.ts
+++ b/packages/witness/src/claim-receipt.ts
@@ -79,10 +79,16 @@ export interface ClaimVerification {
 }
 
 const HEX64 = /^[0-9a-f]{64}$/;
-const SAFE_ID = /^[A-Za-z0-9][A-Za-z0-9._:/@]{0,255}$/;
+const SAFE_ID = /^[A-Za-z0-9][A-Za-z0-9._:/@-]{0,255}$/;
 
 function sha256Hex(input: string): string {
   return createHash('sha256').update(input).digest('hex');
+}
+
+function compareAscii(left: string, right: string): number {
+  if (left < right) return -1;
+  if (left > right) return 1;
+  return 0;
 }
 
 function validateId(value: string, name: string): void {
@@ -114,7 +120,7 @@ function uniqueSorted(values: readonly string[], name: string): string[] {
     seen.add(value);
     out.push(value);
   }
-  return out.sort();
+  return out.sort(compareAscii);
 }
 
 /**
@@ -211,11 +217,10 @@ function canonicalizeEvidence(
       terminal: record.terminal,
     });
   }
-  canonical.sort((a, b) =>
-    a.assignmentId === b.assignmentId
-      ? a.fieldGroup.localeCompare(b.fieldGroup)
-      : a.assignmentId.localeCompare(b.assignmentId),
-  );
+  canonical.sort((left, right) => {
+    const assignmentOrder = compareAscii(left.assignmentId, right.assignmentId);
+    return assignmentOrder === 0 ? compareAscii(left.fieldGroup, right.fieldGroup) : assignmentOrder;
+  });
   return canonical;
 }
 
@@ -224,6 +229,7 @@ export function hashEvidenceRecords(
   manifest: ExperimentManifest,
   records: readonly EvidenceRecord[],
 ): string {
+  hashExperimentManifest(manifest);
   const assignmentIds = new Set(manifest.assignments.map((assignment) => assignment.id));
   const canonical = canonicalizeEvidence(records, assignmentIds);
   return sha256Hex(JSON.stringify(canonical));
@@ -279,7 +285,9 @@ export function verifyClaimEvidence(
     return invalidReceipt(manifestDigest, claimDigest, 'manifest digest mismatch');
   }
 
-  const assignmentIds = manifest.assignments.map((assignment) => assignment.id).sort();
+  const assignmentIds = manifest.assignments
+    .map((assignment) => assignment.id)
+    .sort(compareAscii);
   let canonicalEvidence: CanonicalEvidence[];
   try {
     canonicalEvidence = canonicalizeEvidence(records, new Set(assignmentIds));
@@ -287,8 +295,10 @@ export function verifyClaimEvidence(
     return invalidReceipt(manifestDigest, claimDigest, (error as Error).message);
   }
   const evidenceDigest = sha256Hex(JSON.stringify(canonicalEvidence));
-  const byIdentity = new Map(
-    canonicalEvidence.map((record) => [`${record.assignmentId}\u0000${record.fieldGroup}`, record]),
+  const byIdentity = new Map<string, CanonicalEvidence>(
+    canonicalEvidence.map(
+      (record) => [`${record.assignmentId}\u0000${record.fieldGroup}`, record] as const,
+    ),
   );
 
   const terminalAssignments = new Set(
@@ -313,7 +323,7 @@ export function verifyClaimEvidence(
     };
   }
 
-  const requiredFields = [...claim.requiredFieldGroups].sort();
+  const requiredFields = [...claim.requiredFieldGroups].sort(compareAscii);
   const openedFields = new Set(claim.requireOpenedFieldGroups ?? []);
   const missingFields: string[] = [];
   const missingOpenings: string[] = [];

--- a/packages/witness/src/index.ts
+++ b/packages/witness/src/index.ts
@@ -13,6 +13,8 @@
  */
 import { createHash } from 'node:crypto';
 
+export * from './claim-receipt.js';
+
 /** A 40-char lowercase hex git commit sha (short shas of >=7 also accepted). */
 export type CommitSha = string;
 

--- a/scripts/bench-claim-receipt.mjs
+++ b/scripts/bench-claim-receipt.mjs
@@ -1,0 +1,161 @@
+import { arch, cpus, platform } from 'node:os';
+import { performance } from 'node:perf_hooks';
+import { createHash } from 'node:crypto';
+import {
+  hashExperimentManifest,
+  verifyClaimEvidence,
+} from '../packages/witness/dist/claim-receipt.js';
+
+const SAMPLE_SIZE = 1_000;
+const WARMUP_RUNS = 25;
+const MEASURED_RUNS = 100;
+const SEED = 'claim-receipt-bench-v1';
+
+function digest(value) {
+  return createHash('sha256').update(value).digest('hex');
+}
+
+function percentile(values, fraction) {
+  const ordered = [...values].sort((left, right) => left - right);
+  const index = Math.min(ordered.length - 1, Math.floor(ordered.length * fraction));
+  return ordered[index];
+}
+
+function genericAssignmentPresence(manifest, records) {
+  const present = new Set(records.map((record) => record.assignmentId));
+  return manifest.assignments.every((assignment) => present.has(assignment.id));
+}
+
+const assignments = Array.from({ length: SAMPLE_SIZE }, (_, index) => ({
+  id: `a-${String(index).padStart(4, '0')}`,
+}));
+const manifest = {
+  experimentId: 'claim-receipt-scale',
+  protocolVersion: 'cr-ruv-1',
+  committedAt: '2026-09-03T12:00:00.000Z',
+  assignments,
+};
+const claim = {
+  claimId: 'quality-and-cost',
+  requiredFieldGroups: ['outcome', 'cost'],
+  requireOpenedFieldGroups: ['outcome'],
+};
+const evidence = assignments.flatMap(({ id }) => [
+  {
+    assignmentId: id,
+    fieldGroup: 'outcome',
+    digest: digest(`${SEED}:${id}:outcome`),
+    opened: true,
+    terminal: true,
+  },
+  {
+    assignmentId: id,
+    fieldGroup: 'cost',
+    digest: digest(`${SEED}:${id}:cost`),
+    opened: false,
+    terminal: false,
+  },
+]);
+const manifestDigest = hashExperimentManifest(manifest);
+
+for (let index = 0; index < WARMUP_RUNS; index += 1) {
+  const receipt = verifyClaimEvidence(manifest, manifestDigest, claim, evidence);
+  if (receipt.status !== 'PASS') throw new Error(`warmup failed: ${receipt.status}`);
+  if (!genericAssignmentPresence(manifest, evidence)) throw new Error('baseline warmup failed');
+}
+
+const candidateMs = [];
+const baselineMs = [];
+const beforeHeap = process.memoryUsage().heapUsed;
+for (let index = 0; index < MEASURED_RUNS; index += 1) {
+  let started = performance.now();
+  const receipt = verifyClaimEvidence(manifest, manifestDigest, claim, evidence);
+  candidateMs.push(performance.now() - started);
+  if (receipt.status !== 'PASS') throw new Error(`candidate failed: ${receipt.status}`);
+
+  started = performance.now();
+  if (!genericAssignmentPresence(manifest, evidence)) throw new Error('baseline failed');
+  baselineMs.push(performance.now() - started);
+}
+const afterHeap = process.memoryUsage().heapUsed;
+
+const targetId = assignments[Math.floor(SAMPLE_SIZE / 2)].id;
+const outcomeIndex = evidence.findIndex(
+  (record) => record.assignmentId === targetId && record.fieldGroup === 'outcome',
+);
+const costIndex = evidence.findIndex(
+  (record) => record.assignmentId === targetId && record.fieldGroup === 'cost',
+);
+const missingTerminal = evidence.map((record, index) =>
+  index === outcomeIndex ? { ...record, terminal: false } : record,
+);
+const missingField = evidence.filter((_, index) => index !== costIndex);
+const withheldOpening = evidence.map((record, index) =>
+  index === outcomeIndex ? { ...record, opened: false } : record,
+);
+const malformedDigest = evidence.map((record, index) =>
+  index === outcomeIndex ? { ...record, digest: 'deadbeef' } : record,
+);
+const undeclared = [
+  ...evidence,
+  {
+    assignmentId: 'a-extra',
+    fieldGroup: 'outcome',
+    digest: digest('undeclared'),
+    opened: true,
+    terminal: true,
+  },
+];
+const rewrittenManifest = {
+  ...manifest,
+  assignments: manifest.assignments.slice(0, SAMPLE_SIZE - 1),
+};
+const attacks = [
+  { manifest, evidence: missingTerminal },
+  { manifest, evidence: missingField },
+  { manifest, evidence: withheldOpening },
+  { manifest, evidence: malformedDigest },
+  { manifest, evidence: undeclared },
+  { manifest: rewrittenManifest, evidence },
+];
+let baselineFalsePasses = 0;
+let candidateFalsePasses = 0;
+for (const attack of attacks) {
+  if (genericAssignmentPresence(attack.manifest, attack.evidence)) baselineFalsePasses += 1;
+  if (verifyClaimEvidence(attack.manifest, manifestDigest, claim, attack.evidence).status === 'PASS') {
+    candidateFalsePasses += 1;
+  }
+}
+
+const report = {
+  benchmark: SEED,
+  sampleSize: SAMPLE_SIZE,
+  evidenceRecords: evidence.length,
+  warmupRuns: WARMUP_RUNS,
+  measuredRuns: MEASURED_RUNS,
+  environment: {
+    node: process.version,
+    platform: platform(),
+    arch: arch(),
+    cpu: cpus()[0]?.model ?? 'unknown',
+  },
+  genericPresence: {
+    p50Ms: percentile(baselineMs, 0.5),
+    p95Ms: percentile(baselineMs, 0.95),
+    falsePasses: baselineFalsePasses,
+    attacks: attacks.length,
+  },
+  claimReceipt: {
+    p50Ms: percentile(candidateMs, 0.5),
+    p95Ms: percentile(candidateMs, 0.95),
+    falsePasses: candidateFalsePasses,
+    attacks: attacks.length,
+  },
+  heapDeltaBytes: afterHeap - beforeHeap,
+};
+
+console.log(`CLAIM_RECEIPT_PRODUCTION_BENCH ${JSON.stringify(report)}`);
+
+if (candidateFalsePasses !== 0) {
+  throw new Error(`candidate false passes: ${candidateFalsePasses}`);
+}


### PR DESCRIPTION
Implements the production candidate from #70 and ADR 0003.

## What changes

Adds a deterministic claim-relative verifier to `@dream-machine/witness` that separates experiment coverage from claim-specific evidence sufficiency.

The verifier binds:

1. a precommitted experiment manifest
2. an independently anchored manifest digest
3. a claim specification
4. typed evidence records

It returns `PASS`, `INVALID`, `INCONCLUSIVE_COVERAGE`, or `INCONCLUSIVE_SUFFICIENCY` and explicitly carries `authority: none`.

## Security properties

* manifest assignment order is canonicalized
* noncanonical timestamps are rejected
* undeclared assignments are rejected
* duplicate evidence identities are rejected
* malformed evidence digests are rejected
* required private openings are claim-specific
* terminal evidence is checked against every committed assignment
* expected manifest digest must be anchored outside the verifier
* raw private evidence is not stored in the receipt
* assignment and evidence counts are bounded

## Tests

Adds adversarial tests for omitted terminal evidence, omitted claim fields, withheld openings, undeclared assignments, duplicates, rewritten manifests, malformed digests, invalid claim requirements, and noncanonical commitment timestamps.

## Governance

This PR remains draft. A PASS receipt means declared evidence is present, not that a scientific claim is true. It does not grant RVM authority.

Before promotion: repository CI, lint, typecheck, dependency review, CodeQL, p95 benchmark at 1,000 assignments, and independent MetaHarness reproduction must all have resolved results.

No autonomous merge.