### PR TITLE
docs: require failure attribution before mutation

### DIFF
--- a/docs/adrs/0005-failure-attribution-before-mutation.md
+++ b/docs/adrs/0005-failure-attribution-before-mutation.md
@@ -1,0 +1,52 @@
+# ADR 0005: Attribute Failure Before Mutation
+
+Status: Proposed
+
+## Context
+
+Self improvement loops can waste evaluation budget and increase regression risk when they mutate memory, skills, prompts, tools, or harness behavior before identifying which stage actually failed.
+
+## Decision
+
+Dream Machine will treat failure attribution as a first class experimental artifact before any adaptive mutation is promoted.
+
+The initial taxonomy is deliberately small and deterministic:
+
+* planning
+* execution
+* memory retrieval
+* memory write
+* tool selection
+* tool execution
+* verification
+* environment or dependency
+* unknown
+
+Each failed trajectory receives a `FailureAttributionReceipt` containing trajectory digest, evaluator digest, attributed stage, evidence references, confidence, candidate mutation surface, and authority set to none.
+
+## Experiment
+
+Compare four matched conditions:
+
+1. current Dream Machine behavior
+2. deterministic stage attribution
+3. model based attribution
+4. stage attribution plus skill level credit assignment
+
+Hold model, tasks, seeds, evaluator, token budget, and experiment budget constant.
+
+## Promotion gate
+
+A new attribution mechanism advances only if it produces at least 5 absolute percentage points higher held out task success, or equal task success with at least 25 percent fewer mutation evaluations, while protected slices regress no more than 2 points.
+
+A deterministic taxonomy wins by default when it performs within variance of a model based attribution method.
+
+## Governance
+
+Attribution is evidence, never execution authority. Evaluators remain immutable during a claim family. Failed and null experiments remain in the Dream Machine ledger. No autonomous merge or deployment is permitted.
+
+## Rollback
+
+The feature is additive. Disabling attribution returns candidate generation to the current baseline without data migration.
+
+Tracks issue #73.

--- a/docs/adrs/ADR-0005-failure-attribution-before-mutation.md
+++ b/docs/adrs/ADR-0005-failure-attribution-before-mutation.md
@@ -1,6 +1,7 @@
 # ADR 0005: Attribute Failure Before Mutation
 
 Status: Proposed
+Date: 2026-09-03
 
 ## Context
 

--- a/docs/adrs/INDEX.md
+++ b/docs/adrs/INDEX.md
@@ -9,6 +9,7 @@ Alternatives Considered → Test Contract → References.
 |-----|-------|--------|
 | [ADR-0001](./ADR-0001-dream-machine-engine.md) | The Dream Machine engine — a config-driven, evidence-gated nightly evolution loop composed from the ruvnet stack | Accepted (v0.1.0 shipped) |
 | [ADR-0002](./ADR-0002-dream-cycle-security-adversarial-entrypoint-liveness.md) | Evaluator entrypoints must be classified live/blocked/suspicious-silent before an EVALUATED verdict is recorded | Proposed |
+| [ADR-0005](./ADR-0005-failure-attribution-before-mutation.md) | Attribute failure before mutation | Proposed |
 
 ## How to amend
 


### PR DESCRIPTION
Tracks #73.

Adds ADR 0005 for attribution before mutation in Dream Machine self improvement loops.

The experiment compares current behavior, deterministic stage attribution, model based attribution, and stage plus skill credit under fixed models, tasks, seeds, evaluator, and budget.

Promotion requires at least 5 absolute points higher held out success or equal success with at least 25 percent fewer mutation evaluations. Deterministic attribution wins by default when it is within variance of a model based method.

No evaluator mutation, authority expansion, autonomous merge, or deployment is introduced.