### PR TITLE
feat: require root-cause evidence for security patch promotion

### DIFF
--- a/docs/adrs/ADR-0006-root-cause-security-patch-evaluation.md
+++ b/docs/adrs/ADR-0006-root-cause-security-patch-evaluation.md
@@ -1,0 +1,44 @@
+# ADR 0006: Root Cause Security Patch Evaluation
+
+Status: Proposed
+Date: 2026-09-04
+Tracks: ruvnet/dream-machine#76
+
+## Context
+
+Autonomous repair can appear successful when the original proof of concept stops crashing even though the vulnerability remains. PatchBench, arXiv:2609.04075, submitted 2026-09-03, reports that original-PoC-only validation inflates agent solve rate by 1.83 times on average across 11 evaluated agents. The originating team also reports historical-fix similarity in 25 percent of agent patches and a recurring tendency to suppress the observed crash rather than repair the underlying vulnerability. RuV has not independently reproduced those results.
+
+Dream Machine already requires frozen evaluators and held-out promotion. Security repair needs a stricter reusable contract because a single triggering crash is an especially weak proxy for the protected property.
+
+## Decision
+
+Add a deterministic root-cause security patch evaluation contract to `@dream-machine/witness`.
+
+Before candidate outcomes are visible, the evaluator freezes:
+
+1. vulnerability class
+2. root-cause oracle identity
+3. transformed or transplanted attack case identities
+4. legitimate negative-control identities
+
+The candidate evidence records the original PoC outcome, all frozen transformed attack outcomes, all negative controls, an independent root-cause oracle result, the regression-suite result, and optional historical-patch similarity telemetry.
+
+Promotion fails closed when any frozen case is missing, any unexpected post-outcome case appears, a transformed attack remains successful, a negative control regresses, the root-cause oracle fails, or the regression suite fails. The contract is canonically hashed so equivalent case order produces the same digest.
+
+Patch similarity is telemetry, not an automatic rejection criterion. A correct independent repair may legitimately resemble a historical patch. Similarity should trigger provenance review rather than become a proxy for correctness.
+
+Every verdict explicitly carries `authority: none`. Evaluation success never grants runtime or merge authority.
+
+## Security and governance
+
+The evaluator owns case identities and results. Candidate code must not generate or alter its own oracle result. Evaluator changes after candidate outcomes become visible create a new experiment family. Attack payloads remain in the independent evaluation corpus rather than model-facing documentation.
+
+## Benchmark
+
+MetaHarness issue 281 compares crash-only validation, crash plus regression tests, and the root-cause contract on frozen seeded vulnerability-repair tasks. Report apparent solve rate, root-cause solve rate, false promotion, legitimate patch rejection, evaluator time, model cost, patch similarity, regressions, and exact reproduction steps.
+
+Promotion requires at least 50 percent lower false security promotion than the stronger existing evaluator while legitimate patch acceptance stays within three absolute percentage points.
+
+## Rollback
+
+The implementation is additive to the witness package and changes no existing Dream Machine promotion path by default. Removing the module and export restores previous behavior. No persistent-state migration is required.

--- a/packages/witness/src/index.ts
+++ b/packages/witness/src/index.ts
@@ -116,3 +116,5 @@ export function verifySteps(gistRawUrl = '<RAW_GIST_URL>'): string {
     '# ^ this value MUST equal the published WITNESS',
   ].join('\n');
 }
+
+export * from './security-patch.js';

--- a/packages/witness/src/security-patch.test.ts
+++ b/packages/witness/src/security-patch.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, it } from 'vitest';
+import {
+  evaluateSecurityPatch,
+  securityPatchContractDigest,
+  type SecurityPatchContract,
+  type SecurityPatchEvidence,
+} from './security-patch.js';
+
+const contract: SecurityPatchContract = {
+  vulnerabilityClass: 'CWE-787',
+  rootCauseOracleId: 'oracle:bounds-check',
+  transformedCaseIds: ['xform:layout', 'xform:transplant'],
+  negativeControlIds: ['negative:valid-input'],
+};
+
+function validEvidence(): SecurityPatchEvidence {
+  return {
+    originalPocBlocked: true,
+    transformedCases: [
+      { id: 'xform:layout', passed: true },
+      { id: 'xform:transplant', passed: true },
+    ],
+    negativeControls: [{ id: 'negative:valid-input', passed: true }],
+    rootCauseSatisfied: true,
+    regressionSuitePassed: true,
+    patchSimilarity: 0.21,
+  };
+}
+
+describe('security patch evaluation', () => {
+  it('accepts only complete root-cause evidence', () => {
+    const verdict = evaluateSecurityPatch(contract, validEvidence());
+    expect(verdict.accepted).toBe(true);
+    expect(verdict.reasons).toEqual([]);
+    expect(verdict.authority).toBe('none');
+    expect(verdict.patchSimilarity).toBe(0.21);
+  });
+
+  it('rejects a crash-only patch that misses the root cause and transformed attacks', () => {
+    const evidence = validEvidence();
+    evidence.rootCauseSatisfied = false;
+    evidence.transformedCases = [
+      { id: 'xform:layout', passed: false },
+      { id: 'xform:transplant', passed: false },
+    ];
+    const verdict = evaluateSecurityPatch(contract, evidence);
+    expect(verdict.accepted).toBe(false);
+    expect(verdict.reasons).toContain('root-cause oracle did not pass');
+    expect(verdict.reasons).toContain('transformedCases: failed xform:layout');
+  });
+
+  it('fails closed when a frozen transformed case is missing', () => {
+    const evidence = validEvidence();
+    evidence.transformedCases = [{ id: 'xform:layout', passed: true }];
+    const verdict = evaluateSecurityPatch(contract, evidence);
+    expect(verdict.accepted).toBe(false);
+    expect(verdict.reasons).toContain('transformedCases: missing xform:transplant');
+  });
+
+  it('fails closed on unexpected evaluator cases', () => {
+    const evidence = validEvidence();
+    evidence.transformedCases = [
+      ...evidence.transformedCases,
+      { id: 'xform:post-outcome-added', passed: true },
+    ];
+    const verdict = evaluateSecurityPatch(contract, evidence);
+    expect(verdict.accepted).toBe(false);
+    expect(verdict.reasons).toContain('transformedCases: unexpected xform:post-outcome-added');
+  });
+
+  it('rejects legitimate-behavior regression', () => {
+    const evidence = validEvidence();
+    evidence.negativeControls = [{ id: 'negative:valid-input', passed: false }];
+    const verdict = evaluateSecurityPatch(contract, evidence);
+    expect(verdict.accepted).toBe(false);
+    expect(verdict.reasons).toContain('negativeControls: failed negative:valid-input');
+  });
+
+  it('rejects a failed regression suite even when security cases pass', () => {
+    const evidence = validEvidence();
+    evidence.regressionSuitePassed = false;
+    expect(evaluateSecurityPatch(contract, evidence).accepted).toBe(false);
+  });
+
+  it('rejects duplicate evidence identities', () => {
+    const evidence = validEvidence();
+    evidence.transformedCases = [
+      { id: 'xform:layout', passed: true },
+      { id: 'xform:layout', passed: true },
+    ];
+    expect(() => evaluateSecurityPatch(contract, evidence)).toThrow(/duplicate result/);
+  });
+
+  it('rejects invalid similarity telemetry', () => {
+    const evidence = validEvidence();
+    evidence.patchSimilarity = 1.1;
+    expect(() => evaluateSecurityPatch(contract, evidence)).toThrow(/patchSimilarity/);
+  });
+
+  it('canonicalizes case order when hashing the frozen contract', () => {
+    const reordered: SecurityPatchContract = {
+      ...contract,
+      transformedCaseIds: [...contract.transformedCaseIds].reverse(),
+    };
+    expect(securityPatchContractDigest(reordered)).toBe(securityPatchContractDigest(contract));
+  });
+});

--- a/packages/witness/src/security-patch.ts
+++ b/packages/witness/src/security-patch.ts
@@ -1,0 +1,146 @@
+import { createHash } from 'node:crypto';
+
+/** One precommitted binary evaluator case. */
+export interface SecurityCaseResult {
+  /** Stable evaluator-owned case identity. */
+  id: string;
+  /** Whether the candidate produced the required safe outcome for this case. */
+  passed: boolean;
+}
+
+/** Frozen evaluator universe for one autonomous vulnerability-repair experiment. */
+export interface SecurityPatchContract {
+  /** Stable vulnerability class, for example CWE-787. */
+  vulnerabilityClass: string;
+  /** Stable identifier for the independently reviewed root-cause oracle. */
+  rootCauseOracleId: string;
+  /** Exact transformed or transplanted exploit cases required for promotion. */
+  transformedCaseIds: readonly string[];
+  /** Exact negative controls that must preserve legitimate behavior. */
+  negativeControlIds: readonly string[];
+}
+
+/** Candidate outcomes collected by an evaluator that the candidate cannot modify. */
+export interface SecurityPatchEvidence {
+  /** Whether the original proof of concept no longer violates the protected property. */
+  originalPocBlocked: boolean;
+  /** Results for the frozen transformed attack universe. */
+  transformedCases: readonly SecurityCaseResult[];
+  /** Results for the frozen legitimate-behavior controls. */
+  negativeControls: readonly SecurityCaseResult[];
+  /** Independent root-cause oracle result. */
+  rootCauseSatisfied: boolean;
+  /** Existing regression suite result. */
+  regressionSuitePassed: boolean;
+  /** Optional similarity to a historical/reference patch, in the closed interval [0, 1]. */
+  patchSimilarity?: number;
+}
+
+/** Deterministic promotion decision for a security patch candidate. */
+export interface SecurityPatchVerdict {
+  /** Whether all frozen security and compatibility requirements passed. */
+  accepted: boolean;
+  /** Reasons that prevented promotion. Empty only when accepted. */
+  reasons: string[];
+  /** Canonical digest of the frozen evaluation contract. */
+  contractDigest: string;
+  /** Security evidence never grants runtime authority. */
+  authority: 'none';
+  /** Patch similarity telemetry when supplied by the evaluator. */
+  patchSimilarity?: number;
+}
+
+function uniqueSorted(values: readonly string[], field: string): string[] {
+  const normalized = values.map((value) => value.trim());
+  if (normalized.some((value) => value.length === 0)) {
+    throw new Error(`${field} contains an empty identifier`);
+  }
+  const unique = new Set(normalized);
+  if (unique.size !== normalized.length) {
+    throw new Error(`${field} contains duplicate identifiers`);
+  }
+  return [...unique].sort();
+}
+
+/** Compute the deterministic digest of a frozen security-patch evaluation contract. */
+export function securityPatchContractDigest(contract: SecurityPatchContract): string {
+  const vulnerabilityClass = contract.vulnerabilityClass.trim();
+  const rootCauseOracleId = contract.rootCauseOracleId.trim();
+  if (!vulnerabilityClass) throw new Error('vulnerabilityClass is required');
+  if (!rootCauseOracleId) throw new Error('rootCauseOracleId is required');
+
+  const canonical = JSON.stringify({
+    vulnerabilityClass,
+    rootCauseOracleId,
+    transformedCaseIds: uniqueSorted(contract.transformedCaseIds, 'transformedCaseIds'),
+    negativeControlIds: uniqueSorted(contract.negativeControlIds, 'negativeControlIds'),
+  });
+  return createHash('sha256').update(canonical).digest('hex');
+}
+
+function resultMap(results: readonly SecurityCaseResult[], field: string): Map<string, boolean> {
+  const map = new Map<string, boolean>();
+  for (const result of results) {
+    const id = result.id.trim();
+    if (!id) throw new Error(`${field} contains an empty identifier`);
+    if (map.has(id)) throw new Error(`${field} contains duplicate result for ${id}`);
+    map.set(id, result.passed);
+  }
+  return map;
+}
+
+function compareUniverse(
+  required: readonly string[],
+  observed: Map<string, boolean>,
+  field: string,
+  reasons: string[],
+): void {
+  const requiredSet = new Set(required);
+  for (const id of required) {
+    if (!observed.has(id)) reasons.push(`${field}: missing ${id}`);
+    else if (!observed.get(id)) reasons.push(`${field}: failed ${id}`);
+  }
+  for (const id of observed.keys()) {
+    if (!requiredSet.has(id)) reasons.push(`${field}: unexpected ${id}`);
+  }
+}
+
+/**
+ * Evaluate a candidate security patch against a precommitted root-cause contract.
+ *
+ * The original PoC becoming harmless is necessary but never sufficient. Every
+ * transformed case, negative control, root-cause oracle, and regression gate
+ * must also pass. Any evaluator-universe mismatch fails closed.
+ */
+export function evaluateSecurityPatch(
+  contract: SecurityPatchContract,
+  evidence: SecurityPatchEvidence,
+): SecurityPatchVerdict {
+  const transformedRequired = uniqueSorted(contract.transformedCaseIds, 'transformedCaseIds');
+  const negativeRequired = uniqueSorted(contract.negativeControlIds, 'negativeControlIds');
+  const transformed = resultMap(evidence.transformedCases, 'transformedCases');
+  const negative = resultMap(evidence.negativeControls, 'negativeControls');
+  const reasons: string[] = [];
+
+  if (!evidence.originalPocBlocked) reasons.push('original proof of concept still violates the property');
+  if (!evidence.rootCauseSatisfied) reasons.push('root-cause oracle did not pass');
+  if (!evidence.regressionSuitePassed) reasons.push('regression suite did not pass');
+  compareUniverse(transformedRequired, transformed, 'transformedCases', reasons);
+  compareUniverse(negativeRequired, negative, 'negativeControls', reasons);
+
+  if (evidence.patchSimilarity !== undefined) {
+    if (!Number.isFinite(evidence.patchSimilarity) || evidence.patchSimilarity < 0 || evidence.patchSimilarity > 1) {
+      throw new Error('patchSimilarity must be a finite number in [0, 1]');
+    }
+  }
+
+  const base = {
+    accepted: reasons.length === 0,
+    reasons,
+    contractDigest: securityPatchContractDigest(contract),
+    authority: 'none' as const,
+  };
+  return evidence.patchSimilarity === undefined
+    ? base
+    : { ...base, patchSimilarity: evidence.patchSimilarity };
+}


### PR DESCRIPTION
Tracks #76.

Implements ADR 0006 as an additive `@dream-machine/witness` evaluation primitive. A security patch is no longer promotable merely because the original PoC stops failing.

The frozen contract binds vulnerability class, root-cause oracle identity, transformed or transplanted attack case identities, and legitimate negative controls. Evaluation fails closed on missing or unexpected evaluator cases, surviving transformed attacks, negative-control regressions, failed root-cause oracle, or failed regression suite. The contract is canonically hashed and every verdict carries `authority: none`.

Patch similarity to a historical/reference fix is retained as telemetry rather than treated as correctness or rejection evidence.

Tests cover complete acceptance, crash-only false success, missing frozen cases, post-outcome case injection, negative-control regression, regression-suite failure, duplicate evidence identities, invalid similarity telemetry, and canonical contract hashing.

MetaHarness #281 owns independent PatchBench-style reproduction. No existing Dream Machine promotion path is enabled or migrated by this PR.

Promotion gate: at least 50% lower false security promotion versus the stronger current evaluator, legitimate patch acceptance within 3 absolute points, complete CI and CodeQL green, immutable evaluator artifacts, no autonomous merge or deployment.