### PR TITLE
feat(witness): add provenance bound environment reconstruction receipts

### DIFF
--- a/docs/adrs/ADR-0008-provenance-bound-environment-reconstruction.md
+++ b/docs/adrs/ADR-0008-provenance-bound-environment-reconstruction.md
@@ -1,4 +1,4 @@
-# ADR 0080: Provenance Bound Environment Reconstruction
+# ADR 0008: Provenance Bound Environment Reconstruction
 
 Status: Proposed
 

--- a/docs/adrs/ADR-0080-provenance-bound-environment-reconstruction.md
+++ b/docs/adrs/ADR-0080-provenance-bound-environment-reconstruction.md
@@ -1,0 +1,119 @@
+# ADR 0080: Provenance Bound Environment Reconstruction
+
+Status: Proposed
+
+Date: 2026-09-05
+
+Related: issue 80
+
+## Context
+
+Agent trajectories often contain enough file operations and tool evidence to rebuild part of the environment in which a task was solved. Recent work on Terminal Universe reports that replaying trajectory evidence and completing missing environment state can create a large corpus of reusable executable environments. This is potentially useful for Dream Machine, MetaHarness, RVForge, Core Memory, and Ruflo because a completed trajectory can become a reproducible evaluation surface rather than a one time transcript.
+
+The security problem is provenance collapse. A reconstruction system may mix three very different facts:
+
+1. bytes directly observed in a trajectory,
+2. bytes recovered from an authoritative repository,
+3. bytes inferred or synthesized to make the environment run.
+
+If those classes are merged, a plausible completion can be mistaken for historical ground truth. A reconstructed environment can then pass tests for the wrong reason, contaminate training data, or become an unsafe execution substrate.
+
+## Decision
+
+Dream Machine will represent reconstruction as a metadata only manifest and deterministic receipt before any environment is materialized or executed.
+
+Each artifact carries a normalized relative path, sha256 content digest, provenance class, required flag, and independent verification flag. Missing artifacts are represented explicitly as gaps rather than silently synthesized away.
+
+The first implementation lives in `@dream-machine/witness` because it is an evidence binding primitive. It does not read raw artifact bytes, materialize files, execute commands, authorize tools, or mutate the source workspace.
+
+## Provenance classes
+
+`trajectory` means the artifact is recoverable from the immutable source trajectory.
+
+`repository` means the artifact is recoverable from a separately identified authoritative repository state.
+
+`completion` means an inference process proposed the artifact.
+
+`generated-dependency` means a dependency completion process generated or resolved the artifact without direct source recovery.
+
+The final two classes are inferred. They never become recovered evidence merely because a verifier later accepts the overall task.
+
+## Invariants
+
+1. The source trajectory digest is mandatory and immutable.
+2. Digests are lowercase sha256 values.
+3. Repository commits, when present, are explicit and validated.
+4. Paths are normalized relative POSIX paths. Absolute paths, backslashes, dot segments, parent segments, duplicate paths, and path overlap between artifacts and gaps fail closed.
+5. Resource bounds are enforced before canonicalization.
+6. A required gap makes the reconstruction insufficient.
+7. A required unverified artifact makes the reconstruction insufficient.
+8. Any unverified inferred artifact makes the reconstruction insufficient.
+9. Canonical manifest digest is stable across artifact and gap ordering.
+10. Receipts contain metadata and digests only, never raw source file content or secrets.
+11. Every receipt carries `authority: none`.
+12. Structural sufficiency never authorizes environment execution. RVM remains the authority boundary.
+
+## Security analysis
+
+### Path escape
+
+A reconstruction manifest is attacker controlled until validated. Relative path validation prevents direct absolute path and parent traversal writes. A future materializer must repeat or consume the same validated representation and must still use a sandbox root.
+
+### Provenance laundering
+
+Completion output is permanently distinguishable from recovered evidence. Verification can establish that an inferred artifact is compatible with a task, but does not rewrite its source class.
+
+### Secret recovery
+
+The receipt stores no bytes. A future reconstruction adapter must classify redacted secrets as gaps and must not attempt credential recovery or secret synthesis.
+
+### Resource exhaustion
+
+Artifact and gap counts plus path lengths are bounded. Materializers will need separate byte, file count, CPU, memory, wall clock, and process limits.
+
+### Execution authority
+
+A valid reconstruction receipt is evidence only. It cannot grant a tool, process, network, filesystem, credential, or deployment capability. Any later execution is separately evaluated by RVM.
+
+## Benchmark
+
+MetaHarness issue 285 Track A freezes at least 100 held out trajectories and compares:
+
+1. raw trajectory replay,
+2. deterministic provenance bound reconstruction,
+3. completion assisted reconstruction.
+
+Record source and candidate commits, environment versions, seeds, sample size, reconstruction success, exact artifact provenance coverage, task verifier success, false reconstruction rate, synthesized as recovered errors, missing dependency rate, latency, model tokens, model cost, storage, environment size, failures, regressions, and reproduction commands.
+
+Adversarial cases include path traversal, duplicate paths, missing required files, forged digests, completion artifacts presented as recovered state, secret redaction, binary gaps, oversized manifests, and conflicting repository evidence.
+
+## Promotion gate
+
+The primitive can advance only after all repository tests and security checks are green and MetaHarness reproduction reports:
+
+1. at least 90 percent exact provenance coverage on reconstructable files,
+2. zero path escapes,
+3. zero inferred artifacts misclassified as recovered evidence,
+4. at least 20 percent more reusable verified tasks per source trajectory,
+5. no more than 10 percent additional orchestration cost,
+6. no execution authority expansion.
+
+A null result is acceptable and should stop further reconstruction architecture if raw replay performs within variance at lower cost.
+
+## Migration and rollback
+
+This change is additive. No existing witness format, ledger row, evaluator, workspace, or training corpus changes. Removing the reconstruction module and its export returns the package to current behavior. No stored production state requires migration.
+
+## Cross stack reuse
+
+Dream Machine uses receipts for self improvement evidence.
+
+MetaHarness uses manifests to reproduce evaluation environments.
+
+RVForge can later package only independently validated manifests.
+
+Core Memory can index receipt metadata without storing raw files.
+
+Ruflo can emit trajectory evidence but cannot upgrade provenance classes.
+
+RVM remains the only authority layer for executing a reconstructed environment.

--- a/docs/adrs/INDEX.md
+++ b/docs/adrs/INDEX.md
@@ -12,6 +12,7 @@ Alternatives Considered → Test Contract → References.
 | [ADR-0005](./ADR-0005-failure-attribution-before-mutation.md) | Attribute failure before mutation | Proposed |
 | [ADR-0006](./ADR-0006-root-cause-security-patch-evaluation.md) | Root cause security patch evaluation | Proposed |
 | [ADR-0007](./ADR-0007-claim-relative-evidence-receipts.md) | Claim-relative evidence receipts bind sufficiency and committed experiment coverage without granting authority | Proposed |
+| [ADR-0008](./ADR-0008-provenance-bound-environment-reconstruction.md) | Provenance bound environment reconstruction | Proposed |
 
 ## How to amend
 

--- a/packages/witness/src/index.ts
+++ b/packages/witness/src/index.ts
@@ -120,3 +120,4 @@ export function verifySteps(gistRawUrl = '<RAW_GIST_URL>'): string {
 }
 
 export * from './security-patch.js';
+export * from './reconstruction.js';

--- a/packages/witness/src/reconstruction.test.ts
+++ b/packages/witness/src/reconstruction.test.ts
@@ -1,3 +1,4 @@
+import { createHash } from 'node:crypto';
 import { describe, expect, it } from 'vitest';
 import {
   createEnvironmentReconstructionReceipt,
@@ -128,5 +129,88 @@ describe('environment reconstruction receipts', () => {
     expect(() => createEnvironmentReconstructionReceipt(manifest({ artifacts }))).toThrow(
       /artifacts exceeds maximum/,
     );
+  });
+
+  describe('locale-independent canonicalization', () => {
+    // These paths sort differently under ICU collation than under UTF-16
+    // code units: en-US yields `_x,a,ä,B`, sv-SE yields `_x,a,B,ä`, while
+    // code-unit order is `B,_x,a,ä`. The reviewer measured two different
+    // manifest digests for the same manifest on en_US vs sv_SE hosts when
+    // the sort used `localeCompare`.
+    const LOCALE_SENSITIVE_PATHS = ['a', 'B', 'ä', '_x'];
+    const CODE_UNIT_ORDER = ['B', '_x', 'a', 'ä'];
+    // Golden digest, computed once after the fix; must hold on every host.
+    const GOLDEN_DIGEST = 'fd561e1671096cfa7953cd3186e591bd3c06c566adf3fd586e6cfbad6ef5ec52';
+
+    function localeSensitiveManifest(paths: readonly string[]): EnvironmentReconstructionManifest {
+      return {
+        schemaVersion: 1,
+        trajectoryDigest: TRAJECTORY_DIGEST,
+        artifacts: paths.map((path) => artifact({ path })),
+        gaps: [],
+      };
+    }
+
+    it('fixture discriminates: locale order differs from code-unit order', () => {
+      const localeOrder = [...LOCALE_SENSITIVE_PATHS].sort((left, right) => left.localeCompare(right));
+      expect(localeOrder).not.toEqual(CODE_UNIT_ORDER);
+      const codeUnitOrder = [...LOCALE_SENSITIVE_PATHS].sort((left, right) =>
+        left < right ? -1 : left > right ? 1 : 0,
+      );
+      expect(codeUnitOrder).toEqual(CODE_UNIT_ORDER);
+    });
+
+    it('digest equals sha256 of the manifest canonicalized in code-unit order', () => {
+      const receipt = createEnvironmentReconstructionReceipt(localeSensitiveManifest(LOCALE_SENSITIVE_PATHS));
+      const expectedCanonical = JSON.stringify({
+        schemaVersion: 1,
+        trajectoryDigest: TRAJECTORY_DIGEST,
+        sourceCommit: null,
+        baseImageDigest: null,
+        artifacts: CODE_UNIT_ORDER.map((path) => ({
+          path,
+          contentDigest: CONTENT_A,
+          source: 'trajectory',
+          required: true,
+          verified: true,
+        })),
+        gaps: [],
+      });
+      const expectedDigest = createHash('sha256').update(expectedCanonical).digest('hex');
+      expect(receipt.manifestDigest).toBe(expectedDigest);
+      expect(receipt.manifestDigest).toBe(GOLDEN_DIGEST);
+    });
+
+    it('digest is independent of input order and of the process locale', () => {
+      const localeOrder = [...LOCALE_SENSITIVE_PATHS].sort((left, right) => left.localeCompare(right));
+      const digests = new Set(
+        [LOCALE_SENSITIVE_PATHS, localeOrder, [...LOCALE_SENSITIVE_PATHS].reverse(), CODE_UNIT_ORDER].map(
+          (paths) => createEnvironmentReconstructionReceipt(localeSensitiveManifest(paths)).manifestDigest,
+        ),
+      );
+      // The golden value was recorded with LC_ALL unset (Intl locale en-US).
+      // Whatever LC_ALL / Intl locale this process runs under (CI, sv_SE,
+      // C), the digest must not move.
+      expect([...digests]).toEqual([GOLDEN_DIGEST]);
+    });
+
+    it('gaps are canonicalized with the same code-unit order', () => {
+      const gaps = LOCALE_SENSITIVE_PATHS.map((path) => ({
+        path: `gap/${path}`,
+        reason: 'not-observed' as const,
+        required: false,
+      }));
+      const left = createEnvironmentReconstructionReceipt({
+        ...localeSensitiveManifest([]),
+        artifacts: [artifact()],
+        gaps,
+      });
+      const right = createEnvironmentReconstructionReceipt({
+        ...localeSensitiveManifest([]),
+        artifacts: [artifact()],
+        gaps: [...gaps].sort((a, b) => a.path.localeCompare(b.path)),
+      });
+      expect(left.manifestDigest).toBe(right.manifestDigest);
+    });
   });
 });

--- a/packages/witness/src/reconstruction.test.ts
+++ b/packages/witness/src/reconstruction.test.ts
@@ -1,0 +1,132 @@
+import { describe, expect, it } from 'vitest';
+import {
+  createEnvironmentReconstructionReceipt,
+  type EnvironmentReconstructionManifest,
+  type ReconstructionArtifact,
+} from './reconstruction.js';
+
+const TRAJECTORY_DIGEST = 'a'.repeat(64);
+const CONTENT_A = 'b'.repeat(64);
+const CONTENT_B = 'c'.repeat(64);
+
+function artifact(overrides: Partial<ReconstructionArtifact> = {}): ReconstructionArtifact {
+  return {
+    path: 'src/index.ts',
+    contentDigest: CONTENT_A,
+    source: 'trajectory',
+    required: true,
+    verified: true,
+    ...overrides,
+  };
+}
+
+function manifest(overrides: Partial<EnvironmentReconstructionManifest> = {}): EnvironmentReconstructionManifest {
+  return {
+    schemaVersion: 1,
+    trajectoryDigest: TRAJECTORY_DIGEST,
+    sourceCommit: '7933c3599abe22df5290f4609d1f93f598feb3de',
+    artifacts: [artifact()],
+    gaps: [],
+    ...overrides,
+  };
+}
+
+describe('environment reconstruction receipts', () => {
+  it('marks a fully verified recovered environment task sufficient', () => {
+    const receipt = createEnvironmentReconstructionReceipt(manifest());
+    expect(receipt.taskSufficient).toBe(true);
+    expect(receipt.recoveredArtifacts).toBe(1);
+    expect(receipt.inferredArtifacts).toBe(0);
+    expect(receipt.verifiedArtifacts).toBe(1);
+    expect(receipt.requiredGaps).toBe(0);
+    expect(receipt.authority).toBe('none');
+    expect(receipt.manifestDigest).toMatch(/^[0-9a-f]{64}$/);
+  });
+
+  it('produces the same digest regardless of artifact and gap ordering', () => {
+    const left = manifest({
+      artifacts: [
+        artifact({ path: 'z/file.ts' }),
+        artifact({ path: 'a/file.ts', contentDigest: CONTENT_B, source: 'repository' }),
+      ],
+      gaps: [
+        { path: 'z/missing.dat', reason: 'binary-unavailable', required: false },
+        { path: 'a/missing.dat', reason: 'not-observed', required: false },
+      ],
+    });
+    const right = manifest({
+      artifacts: [...left.artifacts].reverse(),
+      gaps: [...left.gaps].reverse(),
+    });
+    expect(createEnvironmentReconstructionReceipt(left).manifestDigest).toBe(
+      createEnvironmentReconstructionReceipt(right).manifestDigest,
+    );
+  });
+
+  it('keeps unverified completion output from becoming task sufficient', () => {
+    const receipt = createEnvironmentReconstructionReceipt(
+      manifest({ artifacts: [artifact({ source: 'completion', verified: false, required: false })] }),
+    );
+    expect(receipt.taskSufficient).toBe(false);
+    expect(receipt.inferredArtifacts).toBe(1);
+  });
+
+  it('keeps required gaps from becoming task sufficient', () => {
+    const receipt = createEnvironmentReconstructionReceipt(
+      manifest({ gaps: [{ path: 'package-lock.json', reason: 'not-observed', required: true }] }),
+    );
+    expect(receipt.taskSufficient).toBe(false);
+    expect(receipt.requiredGaps).toBe(1);
+  });
+
+  it('rejects parent path traversal', () => {
+    expect(() =>
+      createEnvironmentReconstructionReceipt(manifest({ artifacts: [artifact({ path: '../secret' })] })),
+    ).toThrow(/relative POSIX|normalized/);
+  });
+
+  it('rejects absolute and backslash paths', () => {
+    expect(() =>
+      createEnvironmentReconstructionReceipt(manifest({ artifacts: [artifact({ path: '/etc/passwd' })] })),
+    ).toThrow(/relative POSIX/);
+    expect(() =>
+      createEnvironmentReconstructionReceipt(manifest({ artifacts: [artifact({ path: 'src\\index.ts' })] })),
+    ).toThrow(/relative POSIX/);
+  });
+
+  it('rejects duplicate reconstruction paths', () => {
+    expect(() =>
+      createEnvironmentReconstructionReceipt(
+        manifest({ artifacts: [artifact(), artifact({ contentDigest: CONTENT_B })] }),
+      ),
+    ).toThrow(/duplicate reconstruction path/);
+  });
+
+  it('rejects a path represented as both an artifact and a gap', () => {
+    expect(() =>
+      createEnvironmentReconstructionReceipt(
+        manifest({ gaps: [{ path: 'src/index.ts', reason: 'not-observed', required: false }] }),
+      ),
+    ).toThrow(/both artifact and gap/);
+  });
+
+  it('rejects malformed provenance digests', () => {
+    expect(() =>
+      createEnvironmentReconstructionReceipt(manifest({ trajectoryDigest: 'NOT-A-DIGEST' })),
+    ).toThrow(/trajectoryDigest/);
+    expect(() =>
+      createEnvironmentReconstructionReceipt(
+        manifest({ artifacts: [artifact({ contentDigest: 'd'.repeat(63) })] }),
+      ),
+    ).toThrow(/contentDigest/);
+  });
+
+  it('rejects resource exhaustion before canonicalization', () => {
+    const artifacts = Array.from({ length: 4097 }, (_, index) =>
+      artifact({ path: `files/${index}`, required: false }),
+    );
+    expect(() => createEnvironmentReconstructionReceipt(manifest({ artifacts }))).toThrow(
+      /artifacts exceeds maximum/,
+    );
+  });
+});

--- a/packages/witness/src/reconstruction.ts
+++ b/packages/witness/src/reconstruction.ts
@@ -83,6 +83,18 @@ const INFERRED_SOURCES = new Set<ReconstructionArtifactSource>([
   'generated-dependency',
 ]);
 
+/**
+ * Code-unit string comparator. `String#localeCompare` sorts by the host ICU
+ * locale (e.g. `ä` sorts after `z` under sv-SE but between `a` and `b` under
+ * en-US), which would make the manifest digest differ by host. Plain `<`/`>`
+ * compares UTF-16 code units and is identical on every host.
+ */
+function compareAscii(left: string, right: string): number {
+  if (left < right) return -1;
+  if (left > right) return 1;
+  return 0;
+}
+
 function assertDigest(value: string, field: string): void {
   if (!HEX64.test(value)) {
     throw new Error(`${field} must be a lowercase 64 character sha256 digest`);
@@ -153,7 +165,7 @@ function assertManifest(manifest: EnvironmentReconstructionManifest): void {
 
 function canonicalManifest(manifest: EnvironmentReconstructionManifest): string {
   const artifacts = [...manifest.artifacts]
-    .sort((a, b) => a.path.localeCompare(b.path))
+    .sort((a, b) => compareAscii(a.path, b.path))
     .map((artifact) => ({
       path: artifact.path,
       contentDigest: artifact.contentDigest,
@@ -162,7 +174,7 @@ function canonicalManifest(manifest: EnvironmentReconstructionManifest): string 
       verified: artifact.verified,
     }));
   const gaps = [...manifest.gaps]
-    .sort((a, b) => a.path.localeCompare(b.path))
+    .sort((a, b) => compareAscii(a.path, b.path))
     .map((gap) => ({ path: gap.path, reason: gap.reason, required: gap.required }));
 
   return JSON.stringify({

--- a/packages/witness/src/reconstruction.ts
+++ b/packages/witness/src/reconstruction.ts
@@ -1,0 +1,216 @@
+import { createHash } from 'node:crypto';
+
+const HEX64 = /^[0-9a-f]{64}$/;
+const COMMIT_RE = /^[0-9a-f]{7,40}$/;
+const MAX_ARTIFACTS = 4096;
+const MAX_GAPS = 4096;
+const MAX_PATH_LENGTH = 512;
+
+export type ReconstructionArtifactSource =
+  | 'trajectory'
+  | 'repository'
+  | 'completion'
+  | 'generated-dependency';
+
+export type ReconstructionGapReason =
+  | 'not-observed'
+  | 'dependency-unresolved'
+  | 'secret-redacted'
+  | 'binary-unavailable';
+
+export interface ReconstructionArtifact {
+  /** Normalized relative POSIX path. Raw content is intentionally excluded. */
+  path: string;
+  /** sha256 of the artifact bytes, lowercase hex. */
+  contentDigest: string;
+  /** Where this artifact came from. Inferred sources never become recovered evidence. */
+  source: ReconstructionArtifactSource;
+  /** Whether the reconstructed task requires this artifact. */
+  required: boolean;
+  /** Whether the artifact has been independently checked against its declared source. */
+  verified: boolean;
+}
+
+export interface ReconstructionGap {
+  /** Normalized relative POSIX path that could not be reconstructed. */
+  path: string;
+  reason: ReconstructionGapReason;
+  required: boolean;
+}
+
+export interface EnvironmentReconstructionManifest {
+  schemaVersion: 1;
+  /** sha256 of the immutable source trajectory or trace bundle. */
+  trajectoryDigest: string;
+  /** Optional source repository commit when the trajectory is repository-bound. */
+  sourceCommit?: string;
+  /** Optional digest of the pinned base image or environment root. */
+  baseImageDigest?: string;
+  artifacts: ReconstructionArtifact[];
+  gaps: ReconstructionGap[];
+}
+
+export interface EnvironmentReconstructionReceipt {
+  schemaVersion: 1;
+  manifestDigest: string;
+  trajectoryDigest: string;
+  taskSufficient: boolean;
+  recoveredArtifacts: number;
+  inferredArtifacts: number;
+  verifiedArtifacts: number;
+  gaps: number;
+  requiredGaps: number;
+  /** Structural reconstruction evidence never grants execution authority. */
+  authority: 'none';
+}
+
+const ARTIFACT_SOURCES = new Set<ReconstructionArtifactSource>([
+  'trajectory',
+  'repository',
+  'completion',
+  'generated-dependency',
+]);
+
+const GAP_REASONS = new Set<ReconstructionGapReason>([
+  'not-observed',
+  'dependency-unresolved',
+  'secret-redacted',
+  'binary-unavailable',
+]);
+
+const INFERRED_SOURCES = new Set<ReconstructionArtifactSource>([
+  'completion',
+  'generated-dependency',
+]);
+
+function assertDigest(value: string, field: string): void {
+  if (!HEX64.test(value)) {
+    throw new Error(`${field} must be a lowercase 64 character sha256 digest`);
+  }
+}
+
+function assertPath(value: string, field: string): void {
+  if (value.length === 0 || value.length > MAX_PATH_LENGTH) {
+    throw new Error(`${field} must be between 1 and ${MAX_PATH_LENGTH} characters`);
+  }
+  if (value.includes('\0') || value.startsWith('/') || value.startsWith('\\') || value.includes('\\')) {
+    throw new Error(`${field} must be a relative POSIX path`);
+  }
+  const parts = value.split('/');
+  if (parts.some((part) => part.length === 0 || part === '.' || part === '..')) {
+    throw new Error(`${field} must be normalized and may not contain empty, dot, or parent segments`);
+  }
+}
+
+function assertManifest(manifest: EnvironmentReconstructionManifest): void {
+  if (manifest.schemaVersion !== 1) {
+    throw new Error(`unsupported reconstruction schema version: ${String(manifest.schemaVersion)}`);
+  }
+  assertDigest(manifest.trajectoryDigest, 'trajectoryDigest');
+  if (manifest.sourceCommit !== undefined && !COMMIT_RE.test(manifest.sourceCommit)) {
+    throw new Error('sourceCommit must be 7 to 40 lowercase hexadecimal characters');
+  }
+  if (manifest.baseImageDigest !== undefined) {
+    assertDigest(manifest.baseImageDigest, 'baseImageDigest');
+  }
+  if (manifest.artifacts.length > MAX_ARTIFACTS) {
+    throw new Error(`artifacts exceeds maximum of ${MAX_ARTIFACTS}`);
+  }
+  if (manifest.gaps.length > MAX_GAPS) {
+    throw new Error(`gaps exceeds maximum of ${MAX_GAPS}`);
+  }
+
+  const paths = new Set<string>();
+  for (const artifact of manifest.artifacts) {
+    assertPath(artifact.path, 'artifact.path');
+    if (paths.has(artifact.path)) {
+      throw new Error(`duplicate reconstruction path: ${artifact.path}`);
+    }
+    paths.add(artifact.path);
+    assertDigest(artifact.contentDigest, `artifact ${artifact.path} contentDigest`);
+    if (!ARTIFACT_SOURCES.has(artifact.source)) {
+      throw new Error(`unsupported artifact source for ${artifact.path}`);
+    }
+    if (typeof artifact.required !== 'boolean' || typeof artifact.verified !== 'boolean') {
+      throw new Error(`artifact ${artifact.path} required and verified must be booleans`);
+    }
+  }
+
+  for (const gap of manifest.gaps) {
+    assertPath(gap.path, 'gap.path');
+    if (paths.has(gap.path)) {
+      throw new Error(`reconstruction path cannot be both artifact and gap: ${gap.path}`);
+    }
+    paths.add(gap.path);
+    if (!GAP_REASONS.has(gap.reason)) {
+      throw new Error(`unsupported gap reason for ${gap.path}`);
+    }
+    if (typeof gap.required !== 'boolean') {
+      throw new Error(`gap ${gap.path} required must be boolean`);
+    }
+  }
+}
+
+function canonicalManifest(manifest: EnvironmentReconstructionManifest): string {
+  const artifacts = [...manifest.artifacts]
+    .sort((a, b) => a.path.localeCompare(b.path))
+    .map((artifact) => ({
+      path: artifact.path,
+      contentDigest: artifact.contentDigest,
+      source: artifact.source,
+      required: artifact.required,
+      verified: artifact.verified,
+    }));
+  const gaps = [...manifest.gaps]
+    .sort((a, b) => a.path.localeCompare(b.path))
+    .map((gap) => ({ path: gap.path, reason: gap.reason, required: gap.required }));
+
+  return JSON.stringify({
+    schemaVersion: 1,
+    trajectoryDigest: manifest.trajectoryDigest,
+    sourceCommit: manifest.sourceCommit ?? null,
+    baseImageDigest: manifest.baseImageDigest ?? null,
+    artifacts,
+    gaps,
+  });
+}
+
+/**
+ * Produce a deterministic metadata-only receipt for a reconstructed environment.
+ *
+ * The function validates provenance structure but never executes reconstructed
+ * commands or reads artifact content. A sufficient reconstruction is still only
+ * evidence; callers must pass any later execution through the normal RVM policy.
+ */
+export function createEnvironmentReconstructionReceipt(
+  manifest: EnvironmentReconstructionManifest,
+): EnvironmentReconstructionReceipt {
+  assertManifest(manifest);
+
+  const manifestDigest = createHash('sha256').update(canonicalManifest(manifest)).digest('hex');
+  const recoveredArtifacts = manifest.artifacts.filter(
+    (artifact) => artifact.source === 'trajectory' || artifact.source === 'repository',
+  ).length;
+  const inferredArtifacts = manifest.artifacts.length - recoveredArtifacts;
+  const verifiedArtifacts = manifest.artifacts.filter((artifact) => artifact.verified).length;
+  const requiredGaps = manifest.gaps.filter((gap) => gap.required).length;
+  const hasRequiredUnverified = manifest.artifacts.some(
+    (artifact) => artifact.required && !artifact.verified,
+  );
+  const hasUnverifiedInference = manifest.artifacts.some(
+    (artifact) => INFERRED_SOURCES.has(artifact.source) && !artifact.verified,
+  );
+
+  return {
+    schemaVersion: 1,
+    manifestDigest,
+    trajectoryDigest: manifest.trajectoryDigest,
+    taskSufficient: requiredGaps === 0 && !hasRequiredUnverified && !hasUnverifiedInference,
+    recoveredArtifacts,
+    inferredArtifacts,
+    verifiedArtifacts,
+    gaps: manifest.gaps.length,
+    requiredGaps,
+    authority: 'none',
+  };
+}


### PR DESCRIPTION
Tracks #80.

Adds ADR 0080 plus a metadata only EnvironmentReconstructionManifest and deterministic EnvironmentReconstructionReceipt in @dream-machine/witness.

The primitive preserves trajectory, repository, completion, and generated dependency provenance as distinct source classes. It rejects absolute paths, backslashes, parent traversal, duplicate paths, artifact and gap overlap, malformed digests, invalid commits, and oversized manifests. Required gaps, required unverified artifacts, or unverified inferred artifacts make the reconstruction insufficient.

Canonical manifest digests are stable across artifact ordering. Receipts contain no raw file content and always carry authority none. This PR does not materialize or execute reconstructed environments and does not change any existing evaluator, ledger, authorization, or deployment path.

Tests cover sufficiency, canonicalization, inferred provenance, required gaps, path attacks, duplicate paths, overlap, malformed digests, resource exhaustion, and the authority boundary.

Promotion remains blocked on repository CI, CodeQL, and independent MetaHarness #285 Track A reproduction. No autonomous merge or deployment.