### PR TITLE
feat(witness): gate scientific promotion on discovery evidence

### DIFF
--- a/docs/adrs/ADR-0009-discovery-evidence-before-promotion.md
+++ b/docs/adrs/ADR-0009-discovery-evidence-before-promotion.md
@@ -1,0 +1,110 @@
+# ADR 0009: Discovery evidence before scientific agent promotion
+
+Status: Proposed
+
+Date: 2026-09-07
+
+Issue: #92
+
+## Context
+
+Dream Machine can already freeze experiment manifests, prove evidence assignment coverage, verify security patch root causes, and preserve environment reconstruction provenance. Those controls answer whether declared evidence exists and whether a bounded evaluator universe was followed. They do not answer whether an open-ended scientific claim performed the discriminating checks needed to deserve promotion.
+
+TruthInsightBench, submitted 2026-09-04, evaluates 40 blind scientific discovery tasks from 40 peer-reviewed studies across 10 domains. On one frozen base model, four coding agent configurations score 58.4 to 60.3 of 100 without statistically reliable pairwise separation. The reported weakness is concentrated in controls, robustness, falsifiability, and cross-dataset generalization rather than basic analysis execution or documentation.
+
+This is relevant to Dream Machine, MetaHarness, Core Memory, RVF, RVM, Cognitum, and autonomous discovery programs. A system can produce complete, replayable evidence for a weak scientific claim. Evidence completeness must therefore remain distinct from evidentiary maturity.
+
+## Decision
+
+Add a deterministic `DiscoveryEvidencePolicy` and `DiscoveryEvidenceReceipt` to `@dream-machine/witness`.
+
+The policy is frozen before candidate outcomes are visible and contains only bounded metadata:
+
+1. stable policy identity
+2. protocol version
+3. canonical commit timestamp
+4. digest of the preregistered hypothesis or objective
+5. exact required scientific criteria
+6. whether evidence must be independent of candidate mutation
+7. minimum replicate count
+
+The first supported criteria are controls, falsification, robustness, cross-dataset generalization, and reproducibility.
+
+Each criterion observation records only its evidence digest, pass or fail state, independence state, and bounded replicate count. Raw datasets, private analyses, prompts, and reports do not enter the receipt by default.
+
+A verdict is one of:
+
+`PASS`: every frozen criterion is present, passed, sufficiently replicated, and independent when required.
+
+`REJECTED`: a criterion failed or violates a frozen independence requirement.
+
+`INCONCLUSIVE`: required evidence is missing or below the frozen replicate minimum.
+
+`INVALID`: the policy digest changed, input is malformed, a criterion is duplicated, or evidence appears for a criterion outside the frozen evaluator universe.
+
+Every receipt has `authority: none`.
+
+## Relationship to existing witness primitives
+
+`ClaimVerification` remains responsible for manifest identity, evidence assignment, required-field coverage, terminal claim coverage, and evidence opening.
+
+`DiscoveryEvidenceReceipt` is a second layer that evaluates the scientific checks attached to a claim. It does not duplicate evidence assignment and it does not claim scientific truth.
+
+The independently anchored policy digest is mandatory. The candidate cannot rewrite the required criteria after seeing results.
+
+## Security properties
+
+1. Policy rewriting fails closed.
+2. Duplicate and undeclared criteria fail closed.
+3. Evidence digests are validated as lowercase SHA 256 values.
+4. Counts are bounded before allocation or aggregation.
+5. Canonical timestamps prevent multiple textual encodings of the same nominal freeze time.
+6. Receipts contain no execution capability and cannot authorize merge, deployment, data release, physical action, or privilege expansion.
+7. Independent evidence is represented explicitly rather than inferred from a model identity string.
+
+The remaining trust boundary is evidence admission. A dishonest evaluator can still assert that an evidence digest represents a valid control. Production use must bind observations to witness-verified evaluator artifacts and, where privileged actions are involved, RVM authorization remains separate.
+
+## Benchmark protocol
+
+Freeze at least 40 blind discovery tasks before evaluation.
+
+Compare three conditions under the same base model, task data, seeds, context budget, and overall evaluator budget:
+
+A. existing Dream Machine promotion evidence only
+
+B. existing evidence plus deterministic discovery evidence gating
+
+C. a TruthInsightBench-compatible scientific maturity scorer as an independent evaluation arm
+
+Record baseline, candidate, workload digest, operating system, runtime versions, model and judge identities, seeds, sample size, criterion-level outcomes, false promotion rate, false rejection rate, task quality, variance, tokens, latency, model cost, failures, regressions, and reproduction commands.
+
+Include deliberately under-supported claims, strong-control claims, missing evidence, malformed evidence, contradictory controls, resource exhaustion attempts, evaluator disagreement, and cross-dataset failures.
+
+## Promotion criteria
+
+The primitive is eligible to advance only when all of the following hold on the frozen benchmark:
+
+1. at least 90 percent of deliberately under-supported claims are prevented from promotion
+2. no more than 5 percent of frozen strong-control claims are rejected
+3. zero capability or authority expansion occurs
+4. deterministic local gate overhead is below 1 percent of total evaluation time, excluding any external scientific judge
+5. independent MetaHarness reproduction reaches the same verdict from pinned commits and seeds
+6. repository tests, dependency review, and security scanning remain green
+
+## Falsification
+
+A model-generated scientific rubric may add cost without improving validity. If a deterministic checklist performs within variance of a model-based scorer on the blind holdout, retain the deterministic gate and reject the additional model dependency.
+
+A passing discovery receipt may still correspond to a false scientific conclusion. This ADR is an evidence-readiness gate, not a truth certificate.
+
+## Migration
+
+Additive only. No stored receipt or existing promotion record is migrated. Existing promotion behavior remains unchanged until an explicit caller adopts the new gate.
+
+## Rollback
+
+Remove the export or stop calling the gate. No data migration, model migration, or persistent format conversion is required.
+
+## Commercial implication
+
+Cognitum can expose a stronger evidence contract for autonomous research systems: a discovery cannot be promoted merely because an agent ran code and produced a report. The system can prove that predefined controls, falsification, robustness, generalization, and reproducibility requirements were evaluated independently before promotion.

--- a/packages/witness/src/discovery-evidence.test.ts
+++ b/packages/witness/src/discovery-evidence.test.ts
@@ -1,0 +1,154 @@
+import { createHash } from 'node:crypto';
+import { describe, expect, it } from 'vitest';
+import {
+  discoveryEvidencePolicyDigest,
+  evaluateDiscoveryEvidence,
+  type DiscoveryEvidenceObservation,
+  type DiscoveryEvidencePolicy,
+} from './discovery-evidence.js';
+
+function digest(value: string): string {
+  return createHash('sha256').update(value).digest('hex');
+}
+
+const POLICY: DiscoveryEvidencePolicy = {
+  policyId: 'truth-insight-repro-v1',
+  protocolVersion: 'discovery-evidence-v1',
+  committedAt: '2026-09-07T12:00:00.000Z',
+  hypothesisDigest: digest('frozen scientific objective'),
+  requiredCriteria: [
+    'controls',
+    'falsification',
+    'robustness',
+    'cross_dataset_generalization',
+    'reproducibility',
+  ],
+  requireIndependentEvidence: true,
+  minReplicates: 2,
+};
+
+function completeEvidence(): DiscoveryEvidenceObservation[] {
+  return POLICY.requiredCriteria.map((criterion) => ({
+    criterion,
+    evidenceDigest: digest(`evidence:${criterion}`),
+    status: 'PASS' as const,
+    independent: true,
+    replicates: 2,
+  }));
+}
+
+describe('discovery evidence gate', () => {
+  it('passes complete independent evidence without granting authority', () => {
+    const receipt = evaluateDiscoveryEvidence(POLICY, discoveryEvidencePolicyDigest(POLICY), completeEvidence());
+    expect(receipt.status).toBe('PASS');
+    expect(receipt.authority).toBe('none');
+    expect(receipt.policyDigest).toMatch(/^[0-9a-f]{64}$/);
+    expect(receipt.evidenceDigest).toMatch(/^[0-9a-f]{64}$/);
+  });
+
+  it('canonicalizes required criteria and evidence ordering', () => {
+    const reorderedPolicy: DiscoveryEvidencePolicy = {
+      ...POLICY,
+      requiredCriteria: [...POLICY.requiredCriteria].reverse(),
+    };
+    expect(discoveryEvidencePolicyDigest(reorderedPolicy)).toBe(discoveryEvidencePolicyDigest(POLICY));
+
+    const expected = discoveryEvidencePolicyDigest(POLICY);
+    const first = evaluateDiscoveryEvidence(POLICY, expected, completeEvidence());
+    const second = evaluateDiscoveryEvidence(POLICY, expected, completeEvidence().reverse());
+    expect(second.evidenceDigest).toBe(first.evidenceDigest);
+  });
+
+  it('is inconclusive when a required criterion is absent', () => {
+    const evidence = completeEvidence().filter((item) => item.criterion !== 'robustness');
+    const receipt = evaluateDiscoveryEvidence(POLICY, discoveryEvidencePolicyDigest(POLICY), evidence);
+    expect(receipt.status).toBe('INCONCLUSIVE');
+    expect(receipt.missingCriteria).toEqual(['robustness']);
+  });
+
+  it('rejects a failed scientific criterion', () => {
+    const evidence = completeEvidence();
+    evidence[0] = { ...evidence[0]!, status: 'FAIL' };
+    const receipt = evaluateDiscoveryEvidence(POLICY, discoveryEvidencePolicyDigest(POLICY), evidence);
+    expect(receipt.status).toBe('REJECTED');
+    expect(receipt.failedCriteria).toEqual([evidence[0]!.criterion]);
+  });
+
+  it('rejects non-independent evidence when independence is required', () => {
+    const evidence = completeEvidence();
+    evidence[1] = { ...evidence[1]!, independent: false };
+    const receipt = evaluateDiscoveryEvidence(POLICY, discoveryEvidencePolicyDigest(POLICY), evidence);
+    expect(receipt.status).toBe('REJECTED');
+    expect(receipt.nonIndependentCriteria).toEqual([evidence[1]!.criterion]);
+  });
+
+  it('is inconclusive when replicate evidence is below the frozen minimum', () => {
+    const evidence = completeEvidence();
+    evidence[2] = { ...evidence[2]!, replicates: 1 };
+    const receipt = evaluateDiscoveryEvidence(POLICY, discoveryEvidencePolicyDigest(POLICY), evidence);
+    expect(receipt.status).toBe('INCONCLUSIVE');
+    expect(receipt.insufficientReplicateCriteria).toEqual([evidence[2]!.criterion]);
+  });
+
+  it('invalidates a rewritten policy against the independently anchored digest', () => {
+    const expected = discoveryEvidencePolicyDigest(POLICY);
+    const rewritten: DiscoveryEvidencePolicy = {
+      ...POLICY,
+      requiredCriteria: ['controls'],
+    };
+    const receipt = evaluateDiscoveryEvidence(rewritten, expected, [completeEvidence()[0]!]);
+    expect(receipt.status).toBe('INVALID');
+    expect(receipt.reason).toMatch(/policy digest mismatch/);
+  });
+
+  it('invalidates duplicate observations', () => {
+    const evidence = completeEvidence();
+    evidence.push({ ...evidence[0]! });
+    const receipt = evaluateDiscoveryEvidence(POLICY, discoveryEvidencePolicyDigest(POLICY), evidence);
+    expect(receipt.status).toBe('INVALID');
+    expect(receipt.reason).toMatch(/duplicate criterion/);
+  });
+
+  it('invalidates evidence for a criterion outside the frozen policy', () => {
+    const narrow: DiscoveryEvidencePolicy = {
+      ...POLICY,
+      requiredCriteria: ['controls'],
+      minReplicates: 1,
+    };
+    const evidence: DiscoveryEvidenceObservation[] = [
+      {
+        criterion: 'controls',
+        evidenceDigest: digest('controls'),
+        status: 'PASS',
+        independent: true,
+        replicates: 1,
+      },
+      {
+        criterion: 'robustness',
+        evidenceDigest: digest('undeclared'),
+        status: 'PASS',
+        independent: true,
+        replicates: 1,
+      },
+    ];
+    const receipt = evaluateDiscoveryEvidence(narrow, discoveryEvidencePolicyDigest(narrow), evidence);
+    expect(receipt.status).toBe('INVALID');
+    expect(receipt.reason).toMatch(/undeclared criterion/);
+  });
+
+  it('invalidates malformed digests, timestamps, and replicate counts', () => {
+    const badPolicy: DiscoveryEvidencePolicy = {
+      ...POLICY,
+      committedAt: '2026-09-07T12:00:00Z',
+    };
+    expect(evaluateDiscoveryEvidence(badPolicy, '0'.repeat(64), completeEvidence()).status).toBe('INVALID');
+
+    const evidence = completeEvidence();
+    evidence[0] = { ...evidence[0]!, evidenceDigest: 'deadbeef' };
+    expect(evaluateDiscoveryEvidence(POLICY, discoveryEvidencePolicyDigest(POLICY), evidence).status).toBe('INVALID');
+
+    const badReplicates = completeEvidence();
+    badReplicates[0] = { ...badReplicates[0]!, replicates: 0 };
+    expect(evaluateDiscoveryEvidence(POLICY, discoveryEvidencePolicyDigest(POLICY), badReplicates).status).toBe('INVALID');
+  });
+});

--- a/packages/witness/src/discovery-evidence.test.ts
+++ b/packages/witness/src/discovery-evidence.test.ts
@@ -151,4 +151,35 @@ describe('discovery evidence gate', () => {
     badReplicates[0] = { ...badReplicates[0]!, replicates: 0 };
     expect(evaluateDiscoveryEvidence(POLICY, discoveryEvidencePolicyDigest(POLICY), badReplicates).status).toBe('INVALID');
   });
+
+  it('invalidates untrusted runtime values that bypass TypeScript types', () => {
+    const expected = discoveryEvidencePolicyDigest(POLICY);
+
+    const badStatus = completeEvidence();
+    badStatus[0] = {
+      ...badStatus[0]!,
+      status: 'UNKNOWN',
+    } as unknown as DiscoveryEvidenceObservation;
+    expect(evaluateDiscoveryEvidence(POLICY, expected, badStatus).reason).toMatch(/must be PASS or FAIL/);
+
+    const badIndependent = completeEvidence();
+    badIndependent[0] = {
+      ...badIndependent[0]!,
+      independent: 'yes',
+    } as unknown as DiscoveryEvidenceObservation;
+    expect(evaluateDiscoveryEvidence(POLICY, expected, badIndependent).reason).toMatch(/must be boolean/);
+
+    const badCriterion = completeEvidence();
+    badCriterion[0] = {
+      ...badCriterion[0]!,
+      criterion: 'novelty_only',
+    } as unknown as DiscoveryEvidenceObservation;
+    expect(evaluateDiscoveryEvidence(POLICY, expected, badCriterion).reason).toMatch(/unknown criterion/);
+
+    const badPolicy = {
+      ...POLICY,
+      requireIndependentEvidence: 'true',
+    } as unknown as DiscoveryEvidencePolicy;
+    expect(evaluateDiscoveryEvidence(badPolicy, '0'.repeat(64), completeEvidence()).reason).toMatch(/must be boolean/);
+  });
 });

--- a/packages/witness/src/discovery-evidence.ts
+++ b/packages/witness/src/discovery-evidence.ts
@@ -58,6 +58,13 @@ const HEX64 = /^[0-9a-f]{64}$/;
 const ID_RE = /^[A-Za-z0-9][A-Za-z0-9._:/@]{0,127}$/;
 const MAX_CRITERIA = 16;
 const MAX_REPLICATES = 1_000_000;
+const ALLOWED_CRITERIA = new Set<DiscoveryCriterion>([
+  'controls',
+  'falsification',
+  'robustness',
+  'cross_dataset_generalization',
+  'reproducibility',
+]);
 
 function sha256(value: string): string {
   return createHash('sha256').update(value).digest('hex');
@@ -87,6 +94,9 @@ function requireCanonicalTimestamp(value: string, field: string): string {
 function normalizedCriteria(values: readonly DiscoveryCriterion[]): DiscoveryCriterion[] {
   if (values.length === 0) throw new Error('requiredCriteria must not be empty');
   if (values.length > MAX_CRITERIA) throw new Error(`requiredCriteria exceeds ${MAX_CRITERIA} items`);
+  for (const value of values) {
+    if (!ALLOWED_CRITERIA.has(value)) throw new Error(`requiredCriteria contains unknown criterion ${String(value)}`);
+  }
   const unique = new Set(values);
   if (unique.size !== values.length) throw new Error('requiredCriteria contains duplicates');
   return [...unique].sort();
@@ -102,6 +112,9 @@ function normalizedMinReplicates(value: number | undefined): number {
 
 /** Canonical digest of the discovery policy frozen before candidate outcomes. */
 export function discoveryEvidencePolicyDigest(policy: DiscoveryEvidencePolicy): string {
+  if (typeof policy.requireIndependentEvidence !== 'boolean') {
+    throw new Error('requireIndependentEvidence must be boolean');
+  }
   const canonical = JSON.stringify({
     policyId: requireId(policy.policyId, 'policyId'),
     protocolVersion: requireId(policy.protocolVersion, 'protocolVersion'),
@@ -124,11 +137,20 @@ function normalizedEvidence(
   const normalized: DiscoveryEvidenceObservation[] = [];
 
   for (const observation of observations) {
+    if (!ALLOWED_CRITERIA.has(observation.criterion)) {
+      throw new Error(`observation contains unknown criterion ${String(observation.criterion)}`);
+    }
     if (!requiredSet.has(observation.criterion)) {
       throw new Error(`observation contains undeclared criterion ${observation.criterion}`);
     }
     if (seen.has(observation.criterion)) {
       throw new Error(`observation contains duplicate criterion ${observation.criterion}`);
+    }
+    if (observation.status !== 'PASS' && observation.status !== 'FAIL') {
+      throw new Error(`status for ${observation.criterion} must be PASS or FAIL`);
+    }
+    if (typeof observation.independent !== 'boolean') {
+      throw new Error(`independent for ${observation.criterion} must be boolean`);
     }
     seen.add(observation.criterion);
     if (!Number.isSafeInteger(observation.replicates) || observation.replicates < 1 || observation.replicates > MAX_REPLICATES) {

--- a/packages/witness/src/discovery-evidence.ts
+++ b/packages/witness/src/discovery-evidence.ts
@@ -55,7 +55,7 @@ export interface DiscoveryEvidenceReceipt {
 }
 
 const HEX64 = /^[0-9a-f]{64}$/;
-const ID_RE = /^[A-Za-z0-9][A-Za-z0-9._:/@]{0,127}$/;
+const ID_RE = /^[A-Za-z0-9][A-Za-z0-9._:/@-]{0,127}$/;
 const MAX_CRITERIA = 16;
 const MAX_REPLICATES = 1_000_000;
 const ALLOWED_CRITERIA = new Set<DiscoveryCriterion>([

--- a/packages/witness/src/discovery-evidence.ts
+++ b/packages/witness/src/discovery-evidence.ts
@@ -1,0 +1,212 @@
+import { createHash } from 'node:crypto';
+
+export type DiscoveryCriterion =
+  | 'controls'
+  | 'falsification'
+  | 'robustness'
+  | 'cross_dataset_generalization'
+  | 'reproducibility';
+
+export type DiscoveryEvidenceStatus = 'PASS' | 'FAIL';
+export type DiscoveryVerdictStatus = 'PASS' | 'REJECTED' | 'INCONCLUSIVE' | 'INVALID';
+
+/** Frozen before candidate outcomes are visible. */
+export interface DiscoveryEvidencePolicy {
+  /** Stable policy identity for this experiment family. */
+  policyId: string;
+  /** Versioned evaluation protocol, independent of the candidate. */
+  protocolVersion: string;
+  /** Canonical ISO 8601 timestamp recording when the policy was frozen. */
+  committedAt: string;
+  /** SHA 256 digest of the preregistered hypothesis or objective. */
+  hypothesisDigest: string;
+  /** Exact scientific checks required before promotion can be considered. */
+  requiredCriteria: readonly DiscoveryCriterion[];
+  /** Require criterion evidence to come from an evaluator independent of the candidate. */
+  requireIndependentEvidence: boolean;
+  /** Minimum independent repetitions required per criterion. Defaults to one. */
+  minReplicates?: number;
+}
+
+/** Bounded evidence about one frozen scientific criterion. Raw research content is not stored here. */
+export interface DiscoveryEvidenceObservation {
+  criterion: DiscoveryCriterion;
+  /** SHA 256 digest of the evidence artifact or evaluator output. */
+  evidenceDigest: string;
+  /** Whether the frozen criterion passed its preregistered check. */
+  status: DiscoveryEvidenceStatus;
+  /** Whether the observation came from an evaluator isolated from candidate mutation. */
+  independent: boolean;
+  /** Number of independent repetitions represented by this observation. */
+  replicates: number;
+}
+
+/** Deterministic scientific evidence readiness receipt. This is evidence, never authority. */
+export interface DiscoveryEvidenceReceipt {
+  status: DiscoveryVerdictStatus;
+  authority: 'none';
+  policyDigest: string;
+  evidenceDigest: string;
+  missingCriteria: DiscoveryCriterion[];
+  failedCriteria: DiscoveryCriterion[];
+  nonIndependentCriteria: DiscoveryCriterion[];
+  insufficientReplicateCriteria: DiscoveryCriterion[];
+  reason?: string;
+}
+
+const HEX64 = /^[0-9a-f]{64}$/;
+const ID_RE = /^[A-Za-z0-9][A-Za-z0-9._:/@]{0,127}$/;
+const MAX_CRITERIA = 16;
+const MAX_REPLICATES = 1_000_000;
+
+function sha256(value: string): string {
+  return createHash('sha256').update(value).digest('hex');
+}
+
+function requireId(value: string, field: string): string {
+  const normalized = value.trim();
+  if (!ID_RE.test(normalized)) {
+    throw new Error(`${field} must be a nonempty bounded identifier`);
+  }
+  return normalized;
+}
+
+function requireDigest(value: string, field: string): string {
+  if (!HEX64.test(value)) throw new Error(`${field} must be 64 lowercase hex characters`);
+  return value;
+}
+
+function requireCanonicalTimestamp(value: string, field: string): string {
+  const parsed = new Date(value);
+  if (!Number.isFinite(parsed.getTime()) || parsed.toISOString() !== value) {
+    throw new Error(`${field} must be canonical ISO 8601 with milliseconds and Z`);
+  }
+  return value;
+}
+
+function normalizedCriteria(values: readonly DiscoveryCriterion[]): DiscoveryCriterion[] {
+  if (values.length === 0) throw new Error('requiredCriteria must not be empty');
+  if (values.length > MAX_CRITERIA) throw new Error(`requiredCriteria exceeds ${MAX_CRITERIA} items`);
+  const unique = new Set(values);
+  if (unique.size !== values.length) throw new Error('requiredCriteria contains duplicates');
+  return [...unique].sort();
+}
+
+function normalizedMinReplicates(value: number | undefined): number {
+  const resolved = value ?? 1;
+  if (!Number.isSafeInteger(resolved) || resolved < 1 || resolved > MAX_REPLICATES) {
+    throw new Error(`minReplicates must be an integer in [1, ${MAX_REPLICATES}]`);
+  }
+  return resolved;
+}
+
+/** Canonical digest of the discovery policy frozen before candidate outcomes. */
+export function discoveryEvidencePolicyDigest(policy: DiscoveryEvidencePolicy): string {
+  const canonical = JSON.stringify({
+    policyId: requireId(policy.policyId, 'policyId'),
+    protocolVersion: requireId(policy.protocolVersion, 'protocolVersion'),
+    committedAt: requireCanonicalTimestamp(policy.committedAt, 'committedAt'),
+    hypothesisDigest: requireDigest(policy.hypothesisDigest, 'hypothesisDigest'),
+    requiredCriteria: normalizedCriteria(policy.requiredCriteria),
+    requireIndependentEvidence: policy.requireIndependentEvidence,
+    minReplicates: normalizedMinReplicates(policy.minReplicates),
+  });
+  return sha256(canonical);
+}
+
+function normalizedEvidence(
+  observations: readonly DiscoveryEvidenceObservation[],
+  required: readonly DiscoveryCriterion[],
+): DiscoveryEvidenceObservation[] {
+  if (observations.length > MAX_CRITERIA) throw new Error(`observations exceeds ${MAX_CRITERIA} items`);
+  const requiredSet = new Set(required);
+  const seen = new Set<DiscoveryCriterion>();
+  const normalized: DiscoveryEvidenceObservation[] = [];
+
+  for (const observation of observations) {
+    if (!requiredSet.has(observation.criterion)) {
+      throw new Error(`observation contains undeclared criterion ${observation.criterion}`);
+    }
+    if (seen.has(observation.criterion)) {
+      throw new Error(`observation contains duplicate criterion ${observation.criterion}`);
+    }
+    seen.add(observation.criterion);
+    if (!Number.isSafeInteger(observation.replicates) || observation.replicates < 1 || observation.replicates > MAX_REPLICATES) {
+      throw new Error(`replicates for ${observation.criterion} must be an integer in [1, ${MAX_REPLICATES}]`);
+    }
+    normalized.push({
+      criterion: observation.criterion,
+      evidenceDigest: requireDigest(observation.evidenceDigest, `evidenceDigest for ${observation.criterion}`),
+      status: observation.status,
+      independent: observation.independent,
+      replicates: observation.replicates,
+    });
+  }
+
+  return normalized.sort((a, b) => a.criterion.localeCompare(b.criterion));
+}
+
+function emptyReceipt(reason: string): DiscoveryEvidenceReceipt {
+  return {
+    status: 'INVALID',
+    authority: 'none',
+    policyDigest: '',
+    evidenceDigest: '',
+    missingCriteria: [],
+    failedCriteria: [],
+    nonIndependentCriteria: [],
+    insufficientReplicateCriteria: [],
+    reason,
+  };
+}
+
+/**
+ * Evaluate whether a discovery claim has the preregistered evidence needed to
+ * enter a promotion decision. A PASS does not establish scientific truth and
+ * never grants runtime authority.
+ */
+export function evaluateDiscoveryEvidence(
+  policy: DiscoveryEvidencePolicy,
+  expectedPolicyDigest: string,
+  observations: readonly DiscoveryEvidenceObservation[],
+): DiscoveryEvidenceReceipt {
+  try {
+    const policyDigest = discoveryEvidencePolicyDigest(policy);
+    requireDigest(expectedPolicyDigest, 'expectedPolicyDigest');
+    if (policyDigest !== expectedPolicyDigest) return emptyReceipt('policy digest mismatch');
+
+    const required = normalizedCriteria(policy.requiredCriteria);
+    const minReplicates = normalizedMinReplicates(policy.minReplicates);
+    const evidence = normalizedEvidence(observations, required);
+    const byCriterion = new Map(evidence.map((observation) => [observation.criterion, observation]));
+
+    const missingCriteria = required.filter((criterion) => !byCriterion.has(criterion));
+    const failedCriteria = evidence
+      .filter((observation) => observation.status === 'FAIL')
+      .map((observation) => observation.criterion);
+    const nonIndependentCriteria = policy.requireIndependentEvidence
+      ? evidence.filter((observation) => !observation.independent).map((observation) => observation.criterion)
+      : [];
+    const insufficientReplicateCriteria = evidence
+      .filter((observation) => observation.replicates < minReplicates)
+      .map((observation) => observation.criterion);
+
+    const evidenceDigest = sha256(JSON.stringify(evidence));
+    let status: DiscoveryVerdictStatus = 'PASS';
+    if (failedCriteria.length > 0 || nonIndependentCriteria.length > 0) status = 'REJECTED';
+    else if (missingCriteria.length > 0 || insufficientReplicateCriteria.length > 0) status = 'INCONCLUSIVE';
+
+    return {
+      status,
+      authority: 'none',
+      policyDigest,
+      evidenceDigest,
+      missingCriteria,
+      failedCriteria,
+      nonIndependentCriteria,
+      insufficientReplicateCriteria,
+    };
+  } catch (error) {
+    return emptyReceipt(error instanceof Error ? error.message : 'invalid discovery evidence');
+  }
+}

--- a/packages/witness/src/index.ts
+++ b/packages/witness/src/index.ts
@@ -14,6 +14,7 @@
 import { createHash } from 'node:crypto';
 
 export * from './claim-receipt.js';
+export * from './discovery-evidence.js';
 
 /** A 40-char lowercase hex git commit sha (short shas of >=7 also accepted). */
 export type CommitSha = string;


### PR DESCRIPTION
Tracks #92.

Adds a deterministic discovery evidence gate to `@dream-machine/witness` for autonomous scientific research promotion.

The new contract freezes a policy before candidate outcomes are visible and requires declared scientific checks such as controls, falsification, robustness, cross-dataset generalization, and reproducibility. It supports independent-evidence requirements, bounded replicate counts, canonical policy and evidence digests, and fail-closed handling for malformed, duplicate, undeclared, missing, failed, or insufficient evidence.

Every receipt returns `authority: none`. This composes with the existing claim evidence receipt and does not claim scientific truth, authorize actions, alter capabilities, merge code, or deploy findings.

ADR 0009 records the benchmark, security boundary, migration, rollback, and falsification conditions.

Promotion remains blocked until repository CI, security review, and independent MetaHarness reproduction complete.