### PR TITLE
fix(compile): refresh self-hosted config assertions stale since autoMerge was disabled

### DIFF
--- a/packages/compile/src/__snapshots__/index.test.ts.snap
+++ b/packages/compile/src/__snapshots__/index.test.ts.snap
@@ -500,7 +500,10 @@ real evaluator, then the candidate on the identical corpus/policy.
 
 Evaluator entrypoints for this repo:
 - bench: \`npm test\`
-- darwin: \`npx @metaharness/darwin evolve\`
+- darwin: \`rm -rf .metaharness && npx @metaharness/darwin evolve . --sandbox mock\`
+
+**Supply-chain warning — unpinned \`npx\` evaluator entrypoint(s):**
+- \`evaluatorEntrypoints.darwin\` runs \`npx @metaharness/darwin\` — not pinned to an exact version. \`npx\` resolves the registry \`latest\` dist-tag fresh on every invocation; it is not governed by this repo's own lockfile. A compromised or bad publish under that package name executes immediately, with no PR and no review. Treat a result from this entrypoint as evidence about "whatever is latest right now", not a reproducible receipt, until it is pinned to an exact version or vendored as a real dependency. Do not silently pin it yourself as part of an unrelated candidate — flag it for human decision.
 
 Do not infer results from logs. Preserve the real receipt. If evaluation is
 blocked by infrastructure/credentials: \`EVALUATED=blocked / VERDICT=INCONCLUSIVE\`
@@ -549,8 +552,13 @@ and the 5-step verifier procedure anyone can reproduce.
 
 # STEP 17–18: PUBLISH GIST + ISSUE
 
-Skip if FALLBACK. Otherwise \`gh gist create --public\` the report, capture
-GIST_URL (never fabricate). Open an issue titled
+Skip if FALLBACK. Otherwise publish the report as a public gist using
+whichever gist-creation capability this environment actually provides
+(\`gh gist create --public\`, an equivalent MCP tool) and capture GIST_URL —
+never fabricate one. Neither present (observed on real nights: \`gh\` absent,
+no MCP gist tool) is not FALLBACK: record \`GIST=LOCAL\`, commit the report
+file itself into the PR as the durable artifact, and continue — gist
+publication is best-effort, not a stop condition. Open an issue titled
 \`[Dream Cycle <DATE>] <deep>: <finding> + <scan1>,<scan2> scan\` with labels
 \`dream-cycle\`, \`research\` plus the surface labels. Body sections
 in order: Rotation, Ledger Check, Deep Dive, Hypothesis, Evaluation Receipt,
@@ -579,13 +587,8 @@ Hypothesis, Candidate, Evaluation Receipt, Baseline, Darwin Lineage, Evidence,
 Reward-Hack Check, Security Review, Regression Analysis, ADR, Gist, Issue,
 Witness, Merge Policy.
 
-**Merge policy (guarded auto-merge ENABLED for this target).** Human review
-is still the default. Auto-merge may occur ONLY for a PR that (a) carries the
-explicit low-risk label configured for this repo, (b) is green on every required
-check, and (c) touched no evaluation/gate/safety infrastructure. Any candidate
-that changed a benchmark, gate, threshold, or security boundary is human-review-
-only, full stop. The session itself still never runs the merge — a separate,
-auditable CI job does, under those conditions.
+**Merge policy.** Human review required. The session never self-merges and
+never autonomously promotes candidate state.
 
 Append exactly ONE row to \`docs/dream-cycle/LEDGER.md\`:
 

--- a/packages/compile/src/index.test.ts
+++ b/packages/compile/src/index.test.ts
@@ -207,8 +207,8 @@ describe('self-hosted config (ruvnet/dream-machine)', () => {
     expect(validateConfig(selfConfig).ok).toBe(true);
   });
 
-  it('resolves autoMerge: true (the one config in the wild that enables it)', () => {
-    expect(withDefaults(selfConfig).autoMerge).toBe(true);
+  it('resolves autoMerge: false (this repo deliberately never auto-merges)', () => {
+    expect(withDefaults(selfConfig).autoMerge).toBe(false);
   });
 
   it('compiles deterministically', () => {


### PR DESCRIPTION
Landing #11 (authored 2026-08-15) turned `main` red: it pins `autoMerge: true` and a golden prompt snapshot to the config as it stood that day, but the repo deliberately set `autoMerge: false` in early September and the compiled prompt has evolved since.

- assertion updated to the current intended value (this repo never auto-merges — `automerge.yml`'s guard job is deliberately never armed)
- golden snapshot regenerated

Verified locally: `packages/compile` 34/34, `npm run check` 80/81 — the one remaining local failure is the macOS-only `/tmp`→`/private/tmp` symlink case in `mission.test.mjs`, which this repo's Linux-only CI does not exercise.

🤖 Generated with [RuFlo](https://github.com/ruvnet/ruflo)

https://claude.ai/code/session_01Ff2xRKvYrqXJhefvcapfE1