### PR TITLE
feat(witness): re-verify the evidence read set before promotion (ADR-0010)

### DIFF
--- a/docs/adrs/ADR-0010-evidence-freshness-before-promotion.md
+++ b/docs/adrs/ADR-0010-evidence-freshness-before-promotion.md
@@ -1,0 +1,134 @@
+# ADR 0010: Evidence freshness — re-verify the read set before promotion
+
+Status: Proposed
+
+Date: 2026-09-07
+
+Related: ADR-0007 (claim-relative evidence receipts), ADR-0009 (discovery evidence before promotion), ADR-0001 (the nightly loop)
+
+## Context
+
+Every evidence gate in this repository freezes a policy *before* outcomes are
+visible and then treats the resulting receipt as timeless. `ClaimReceipt` binds
+experiment coverage. `DiscoveryEvidenceReceipt` binds scientific criteria.
+Neither asks a question that turned out to matter more than either: **is this
+evidence still about the tree we are promoting into?**
+
+That assumption is safe when a candidate lands the same night. It is not safe in
+the regime this repository actually operates in. Between 2026-08-13 and
+2026-09-07, 30+ evaluated candidates accumulated unmerged; the backlog was
+landed in a single session on 2026-09-07.
+
+PR #11 made the failure concrete and measurable. It was evaluated on 2026-08-15
+against `dream.config.json` as it stood that day, asserting
+`withDefaults(selfConfig).autoMerge === true` and golden-snapshotting the
+compiled prompt. Its evaluation was honest and passed. Three weeks later the
+repository deliberately set `autoMerge: false` and the compiled prompt evolved.
+On landing, `main` went red on two tests.
+
+The load-bearing detail is that **git merged #11 cleanly**. There was no
+conflict, because `dream.config.json` was never in #11's diff. It was in #11's
+*read set*: a file the evaluation depended on but did not modify.
+
+> git protects the WRITE set. Nothing here protected the READ set.
+
+This is not "receipts get old". Age was never the mechanism — a three-week-old
+candidate whose dependencies never moved is still valid. The mechanism is an
+**undeclared environmental dependency set that nothing re-verifies at promotion
+time**.
+
+## Decision
+
+Add a deterministic `EvidenceFreshnessPolicy` / `EvidenceFreshnessReceipt` pair
+to `@dream-machine/witness`, and a `dream-machine freshness` CLI that performs
+the I/O.
+
+The policy is frozen at evaluation time and contains only bounded metadata:
+
+1. stable policy identity
+2. the base commit the evaluation ran against
+3. canonical evaluation timestamp
+4. the **declared read set** — every path whose content the evaluation's result
+   depends on, each with a SHA-256 digest of its content at evaluation time
+5. whether an empty read set is rejected (default yes)
+6. an optional secondary `maxAgeDays` bound
+
+At promotion time the same paths are re-digested against the target tree and
+compared. Verdicts:
+
+- `FRESH` — every declared dependency still has its evaluated content
+- `STALE` — one or more drifted, or an explicit age budget was exceeded
+- `INDETERMINATE` — a declared path was not observed, or the observation carries
+  paths the policy never declared; unverifiable is never treated as fresh
+- `INVALID` — malformed input, or the policy no longer matches its anchored digest
+
+Every receipt carries `authority: 'none'`, consistent with ADR-0007/0009. A
+FRESH verdict is evidence that an evaluation still applies. It is never
+permission to merge.
+
+Three deliberate non-goals, because getting them wrong makes the gate useless:
+
+- **A moved base commit is not staleness.** `main` advances constantly; a gate
+  that fires whenever `HEAD != baseCommit` fires always, gets ignored, and
+  protects nothing. `baseCommitMoved` is reported as context only.
+- **Age is not the primary signal.** It is an optional secondary bound for
+  callers who want one, never the mechanism.
+- **The witness primitive performs no I/O.** The caller supplies observed
+  digests, so the same pure function serves CI, a promotion gate, and tests.
+
+## Consequences
+
+A candidate can now carry, alongside its evaluation receipt, a machine-checkable
+claim about the environment that evaluation assumed — and that claim is
+re-checked against the tree it would land in.
+
+The cost is that the read set must be declared. An undeclared read set is not
+evidence that a candidate has no environmental dependencies; it is evidence that
+nobody looked, which is why `requireDeclaredDependencies` defaults to true. Read
+sets that are too narrow will still miss drift; this gate raises the floor, it
+does not prove independence.
+
+This does not close the promotion loop by itself. It supplies the missing
+freshness input that a bounded auto-landing path would need before it could
+safely act on a three-week-old ACCEPT verdict.
+
+## Alternatives Considered
+
+- **Re-run the full evaluation at promotion time.** Strictly stronger and
+  strictly more expensive; for a 30-candidate backlog it is the thing that does
+  not happen, which is how the backlog formed. Freshness is the cheap check that
+  says whether the expensive one is needed.
+- **Gate on base-commit equality.** Trivially implementable, fires on every
+  candidate in a live repository, and would have been switched off within a day.
+- **Gate on age alone.** Would have caught #11 (three weeks old) but also blocks
+  correct old candidates and passes a one-day-old candidate whose dependencies
+  moved. Wrong axis.
+- **Rely on git conflict detection.** This is the status quo, and it is exactly
+  what missed #11: the diff merged cleanly.
+
+## Test Contract
+
+- `FRESH` when the declared read set is unchanged; unaffected by a moved HEAD or
+  by arbitrary age with no drift
+- `STALE` reproducing PR #11's exact shape — a clean merge whose read set drifted
+- `STALE` when an explicit age budget is exceeded; drift reported alongside age
+- `INDETERMINATE` for unobserved declared paths and for undeclared observed paths
+- `INVALID` for a policy rewritten after its digest was anchored (the evasion
+  path: silently dropping the dependency that drifted)
+- rejection of absolute paths, `..` traversal, duplicate paths, malformed
+  digests/commits/timestamps, non-boolean and out-of-range runtime values, and
+  read sets beyond `MAX_EVIDENCE_DEPENDENCIES`
+- receipts contain digests and paths only, never file content
+- the CLI validates and anchors the policy **before** reading any dependency, so
+  an untrusted policy file cannot be used as a read/existence oracle
+- cost bound: sub-quadratic scaling from 512 to 4096 dependencies
+
+Validated end-to-end against real history: stamping `dream.config.json` from
+`8ce3857` (PR #11's evaluation base) and verifying against current `main` yields
+`STALE`, `driftedPaths: ["dream.config.json"]`, exit 1.
+
+## References
+
+- PR #11, PR #95 (the repair), PR #96 (union-merge damage from the same landing)
+- `packages/witness/src/evidence-freshness.ts`
+- ADR-0007, ADR-0009

--- a/docs/adrs/INDEX.md
+++ b/docs/adrs/INDEX.md
@@ -13,6 +13,7 @@ Alternatives Considered → Test Contract → References.
 | [ADR-0006](./ADR-0006-root-cause-security-patch-evaluation.md) | Root cause security patch evaluation | Proposed |
 | [ADR-0007](./ADR-0007-claim-relative-evidence-receipts.md) | Claim-relative evidence receipts bind sufficiency and committed experiment coverage without granting authority | Proposed |
 | [ADR-0008](./ADR-0008-provenance-bound-environment-reconstruction.md) | Provenance bound environment reconstruction | Proposed |
+| [ADR-0010](./ADR-0010-evidence-freshness-before-promotion.md) | Evidence freshness — re-verify the read set before promotion | Proposed |
 | [ADR-0100](./ADR-0100-edge-runtime-trust-boundaries.md) | Separate the Dream Machine control plane from the bedside runtime and actuator safety authority | Proposed |
 | [ADR-0101](./ADR-0101-uno-q-ruview-home-core-runtime.md) | Governed edge runtime on Arduino UNO Q with RuView HOMECORE | Proposed |
 | [ADR-0102](./ADR-0102-apple-watch-healthkit-local-bridge.md) | Apple Watch HealthKit local bridge with retrospective default and research-only live sensing | Proposed |

--- a/packages/cli/src/index.test.ts
+++ b/packages/cli/src/index.test.ts
@@ -248,6 +248,133 @@ describe('ledger', () => {
   });
 });
 
+describe('freshness', () => {
+  const cfgV1 = '{"autoMerge":true}';
+  const cfgV2 = '{"autoMerge":false}';
+  const srcV1 = 'export const compile = 1;';
+
+  async function stampPolicy(files: Record<string, string>, extra: string[] = []) {
+    const io = mockIO(files);
+    const r = await run(
+      ['freshness', 'stamp', '--base', 'abc1234', '--paths', Object.keys(files).join(','), '--out', 'p.json', ...extra],
+      io,
+    );
+    return { io, r };
+  }
+
+  it('stamp freezes the declared read set and reports a policy digest', async () => {
+    const { io, r } = await stampPolicy({ 'dream.config.json': cfgV1, 'src.ts': srcV1 });
+    expect(r.code).toBe(0);
+    const doc = JSON.parse(io.files['p.json']);
+    expect(doc.policyDigest).toMatch(/^[0-9a-f]{64}$/);
+    expect(doc.policy.dependencies.map((d: { path: string }) => d.path).sort()).toEqual([
+      'dream.config.json',
+      'src.ts',
+    ]);
+  });
+
+  it('verify is FRESH (exit 0) when the read set has not moved', async () => {
+    const { io } = await stampPolicy({ 'dream.config.json': cfgV1, 'src.ts': srcV1 });
+    const r = await run(['freshness', 'verify', '--policy', 'p.json', '--head', 'def5678'], io);
+    expect(r.code).toBe(0);
+    expect(JSON.parse(r.out).status).toBe('FRESH');
+  });
+
+  // The PR #11 regression, end to end through the CLI.
+  it('verify is STALE (exit 1) when a read-set file drifted, even with no diff conflict', async () => {
+    const { io } = await stampPolicy({ 'dream.config.json': cfgV1, 'src.ts': srcV1 });
+    io.files['dream.config.json'] = cfgV2; // changed underneath, never in the candidate's diff
+    const r = await run(['freshness', 'verify', '--policy', 'p.json', '--head', 'def5678'], io);
+    expect(r.code).toBe(1);
+    const receipt = JSON.parse(r.out);
+    expect(receipt.status).toBe('STALE');
+    expect(receipt.driftedPaths).toEqual(['dream.config.json']);
+    expect(r.err).toContain('Re-evaluate before promoting');
+  });
+
+  it('verify is indeterminate (exit 2) when a declared dependency vanished', async () => {
+    const { io } = await stampPolicy({ 'dream.config.json': cfgV1, 'src.ts': srcV1 });
+    delete io.files['src.ts'];
+    const r = await run(['freshness', 'verify', '--policy', 'p.json', '--head', 'def5678'], io);
+    expect(r.code).toBe(2);
+    expect(JSON.parse(r.out).status).toBe('INDETERMINATE');
+    expect(r.err).toContain('no longer present');
+  });
+
+  it('verify rejects a policy whose read set was rewritten after stamping', async () => {
+    const { io } = await stampPolicy({ 'dream.config.json': cfgV1, 'src.ts': srcV1 });
+    const doc = JSON.parse(io.files['p.json']);
+    doc.policy.dependencies = doc.policy.dependencies.filter(
+      (d: { path: string }) => d.path !== 'dream.config.json',
+    );
+    io.files['p.json'] = JSON.stringify(doc);
+    io.files['dream.config.json'] = cfgV2;
+    const r = await run(['freshness', 'verify', '--policy', 'p.json', '--head', 'def5678'], io);
+    // Rejected at parse time, before any dependency is read -- so there is no
+    // receipt on stdout at all, which is strictly stronger than emitting an
+    // INVALID one after having already touched the filesystem.
+    expect(r.code).toBe(2);
+    expect(r.out).toBe('');
+    expect(r.err).toMatch(/digest mismatch/);
+  });
+
+  it('stamp fails clearly when a declared dependency cannot be read', async () => {
+    const io = mockIO({ 'a.ts': 'x' });
+    const r = await run(['freshness', 'stamp', '--base', 'abc1234', '--paths', 'a.ts,missing.ts'], io);
+    expect(r.code).toBe(2);
+    expect(r.err).toContain('cannot read declared dependency missing.ts');
+  });
+
+  it('stamp rejects an absolute or traversing dependency path', async () => {
+    const io = mockIO({ '/etc/shadow': 'root' });
+    const r = await run(['freshness', 'stamp', '--base', 'abc1234', '--paths', '/etc/shadow'], io);
+    expect(r.code).toBe(2);
+    expect(r.err).toMatch(/repository-relative/);
+  });
+
+  it('never reads a path outside the repo, even before rejecting the policy', async () => {
+    // Regression: the CLI used to digest every declared path first and only
+    // then let the library reject traversal, which made an attacker-supplied
+    // policy file a read/existence oracle for paths outside the repository.
+    const reads: string[] = [];
+    const io = mockIO({ 'p.json': JSON.stringify({
+      policy: {
+        policyId: 'evil',
+        baseCommit: 'abc1234',
+        evaluatedAt: '2026-09-01T00:00:00.000Z',
+        dependencies: [{ path: '../../../etc/hosts', digest: '0'.repeat(64) }],
+        requireDeclaredDependencies: true,
+      },
+      policyDigest: '0'.repeat(64),
+    }) });
+    const inner = io.readFile.bind(io);
+    io.readFile = async (p: string) => { reads.push(p); return inner(p); };
+
+    const r = await run(['freshness', 'verify', '--policy', 'p.json', '--head', 'abc1234'], io);
+    expect(r.code).toBe(2);
+    expect(reads).toEqual(['p.json']); // the policy itself, and nothing else
+    expect(r.err).toMatch(/malformed policy|traverse/);
+  });
+
+  it('rejects a policy whose digest does not anchor its read set', async () => {
+    const io = mockIO({ 'a.ts': 'x' });
+    await run(['freshness', 'stamp', '--base', 'abc1234', '--paths', 'a.ts', '--out', 'p.json'], io);
+    const doc = JSON.parse(io.files['p.json']);
+    doc.policyDigest = 'f'.repeat(64); // anchor no longer matches the policy
+    io.files['p.json'] = JSON.stringify(doc);
+    const r = await run(['freshness', 'verify', '--policy', 'p.json', '--head', 'def5678'], io);
+    expect(r.code).toBe(2);
+    expect(r.err).toMatch(/digest mismatch/);
+  });
+
+  it('errors with usage on a missing subcommand or flags', async () => {
+    const io = mockIO({});
+    expect((await run(['freshness'], io)).code).toBe(2);
+    expect((await run(['freshness', 'stamp'], io)).code).toBe(2);
+    expect((await run(['freshness', 'verify'], io)).code).toBe(2);
+  });
+});
+
 describe('witness', () => {
   it('stamp prints the triple', async () => {
     const io = mockIO({ 'r.md': 'report body' });

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -17,7 +17,15 @@ import {
   EVALS,
   type LedgerRow,
 } from '@dream-machine/ledger';
-import { stamp, verify, verifySteps } from '@dream-machine/witness';
+import {
+  stamp,
+  verify,
+  verifySteps,
+  evaluateEvidenceFreshness,
+  evidenceFreshnessPolicyDigest,
+  type EvidenceDependency,
+  type EvidenceFreshnessPolicy,
+} from '@dream-machine/witness';
 import { serializeRoutine, scheduleInstructions } from '@dream-machine/schedule';
 import { renderDashboard } from './tui.js';
 import { classifyEntrypointResult, type ExecResult } from './entrypoint.js';
@@ -124,7 +132,9 @@ Commands:
   verify-entrypoint <label> --cmd "<command>"           Classify an evaluator entrypoint's liveness
   tui             [--path LEDGER.md] [--no-color] [--merged "7,12"]  Render the dashboard
   audit-gate      --path <npm-audit.json>               Gate on high/critical findings in an audit report
-  tui             [--path LEDGER.md] [--no-color]      Render the dashboard
+  freshness stamp --base <sha> --paths "a,b" [--out F]  Freeze the evidence read set at evaluation time
+  freshness verify --policy <file> --head <sha>         Re-verify that read set against the promotion target
+                                                         (exit 0 FRESH, 1 STALE, 2 indeterminate/invalid)
   version | --version                                  Print version
   help    | --help                                     This help
 
@@ -386,6 +396,134 @@ export async function run(argv: string[], io: IO): Promise<RunResult> {
         );
         const code = r.verdict === 'clear' ? 0 : r.verdict === 'blocked' ? 1 : 2;
         return { code, out: sink.out, err: sink.err };
+      }
+
+      /**
+       * Evidence freshness gate (see `@dream-machine/witness/evidence-freshness`).
+       *
+       * `stamp` freezes the read set at evaluation time; `verify` re-digests
+       * those same paths against the tree a candidate would land in. The CLI
+       * owns all I/O so the witness primitive stays pure.
+       */
+      case 'freshness': {
+        const sub = _[1];
+        const sha256Hex = async (content: string): Promise<string> =>
+          (await import('node:crypto')).createHash('sha256').update(content).digest('hex');
+
+        if (sub === 'stamp') {
+          const base = flags.base as string | undefined;
+          const pathsFlag = flags.paths as string | undefined;
+          if (!base || !pathsFlag) {
+            sink.error(
+              'usage: dream-machine freshness stamp --base <sha> --paths "a.json,b/c.ts" [--id ID] [--max-age DAYS] [--out FILE]',
+            );
+            return { code: 2, out: sink.out, err: sink.err };
+          }
+          const paths = pathsFlag
+            .split(',')
+            .map((p) => p.trim())
+            .filter(Boolean);
+          const dependencies: EvidenceDependency[] = [];
+          for (const path of paths) {
+            try {
+              dependencies.push({ path, digest: await sha256Hex(await io.readFile(path)) });
+            } catch (e) {
+              sink.error(`freshness stamp: cannot read declared dependency ${path}: ${(e as Error).message}`);
+              return { code: 2, out: sink.out, err: sink.err };
+            }
+          }
+          const maxAgeRaw = flags['max-age'];
+          const policy: EvidenceFreshnessPolicy = {
+            policyId: (flags.id as string) || 'dream-cycle-candidate',
+            baseCommit: base,
+            evaluatedAt: new Date(`${io.now()}T00:00:00.000Z`).toISOString(),
+            dependencies,
+            requireDeclaredDependencies: true,
+            ...(maxAgeRaw === undefined ? {} : { maxAgeDays: Number(maxAgeRaw) }),
+          };
+          let policyDigest: string;
+          try {
+            policyDigest = evidenceFreshnessPolicyDigest(policy);
+          } catch (e) {
+            sink.error(`freshness stamp: ${(e as Error).message}`);
+            return { code: 2, out: sink.out, err: sink.err };
+          }
+          const doc = JSON.stringify({ policy, policyDigest }, null, 2);
+          const out = flags.out as string | undefined;
+          if (out) {
+            await io.writeFile(out, doc + '\n');
+            sink.log(`freshness stamp: wrote ${out} (policyDigest ${policyDigest})`);
+          } else {
+            sink.log(doc);
+          }
+          return { code: 0, out: sink.out, err: sink.err };
+        }
+
+        if (sub === 'verify') {
+          const policyPath = flags.policy as string | undefined;
+          const head = flags.head as string | undefined;
+          if (!policyPath || !head) {
+            sink.error('usage: dream-machine freshness verify --policy <file> --head <sha>');
+            return { code: 2, out: sink.out, err: sink.err };
+          }
+          let doc: { policy: EvidenceFreshnessPolicy; policyDigest: string };
+          try {
+            doc = JSON.parse(await io.readFile(policyPath));
+          } catch (e) {
+            sink.error(`freshness verify: could not read/parse ${policyPath}: ${(e as Error).message}`);
+            return { code: 2, out: sink.out, err: sink.err };
+          }
+          // Validate and anchor the policy BEFORE touching the filesystem.
+          // The policy file is untrusted input: without this, a crafted policy
+          // could name `../../etc/hosts` and make us read (and confirm the
+          // existence of) paths outside the repository, even though the receipt
+          // would later come back INVALID. Fail closed, then read.
+          let anchoredDigest: string;
+          try {
+            anchoredDigest = evidenceFreshnessPolicyDigest(doc.policy);
+          } catch (e) {
+            sink.error(`freshness verify: malformed policy in ${policyPath}: ${(e as Error).message}`);
+            return { code: 2, out: sink.out, err: sink.err };
+          }
+          if (anchoredDigest !== doc.policyDigest) {
+            sink.error(
+              'freshness verify: policy digest mismatch — the read set was rewritten after it was stamped',
+            );
+            return { code: 2, out: sink.out, err: sink.err };
+          }
+
+          // A declared path that no longer exists is simply not observed; the
+          // receipt then reports it as missing (INDETERMINATE), never FRESH.
+          const observedDeps: EvidenceDependency[] = [];
+          const absent: string[] = [];
+          for (const dependency of doc.policy?.dependencies ?? []) {
+            try {
+              observedDeps.push({ path: dependency.path, digest: await sha256Hex(await io.readFile(dependency.path)) });
+            } catch {
+              absent.push(dependency.path);
+            }
+          }
+          const receipt = evaluateEvidenceFreshness(doc.policy, doc.policyDigest, {
+            headCommit: head,
+            observedAt: new Date(`${io.now()}T00:00:00.000Z`).toISOString(),
+            dependencies: observedDeps,
+          });
+          sink.log(JSON.stringify(receipt, null, 2));
+          if (absent.length > 0) {
+            sink.error(`freshness verify: declared dependencies no longer present: ${absent.join(', ')}`);
+          }
+          if (receipt.status === 'STALE') {
+            sink.error(
+              `freshness verify: STALE — the evidence no longer describes this tree ` +
+                `(drifted: ${receipt.driftedPaths.join(', ') || 'none'}${receipt.ageExceeded ? '; age budget exceeded' : ''}). Re-evaluate before promoting.`,
+            );
+          }
+          const code = receipt.status === 'FRESH' ? 0 : receipt.status === 'STALE' ? 1 : 2;
+          return { code, out: sink.out, err: sink.err };
+        }
+
+        sink.error('usage: dream-machine freshness <stamp|verify> ...');
+        return { code: 2, out: sink.out, err: sink.err };
       }
 
       case 'tui': {

--- a/packages/witness/src/evidence-freshness.bench.test.ts
+++ b/packages/witness/src/evidence-freshness.bench.test.ts
@@ -1,0 +1,95 @@
+/**
+ * Cost bound for the freshness gate.
+ *
+ * This runs on every promotion decision, so it has to be cheap enough that
+ * nobody is tempted to skip it -- a gate that costs real time is a gate that
+ * gets disabled. The work is O(n log n) in the read set (one sort per side) and
+ * O(n) to compare, with no I/O, so the bound below is generous on purpose:
+ * it is a regression tripwire against accidental quadratic behaviour, not a
+ * hardware claim.
+ */
+import { createHash } from 'node:crypto';
+import { performance } from 'node:perf_hooks';
+import { describe, expect, it } from 'vitest';
+import {
+  evaluateEvidenceFreshness,
+  evidenceFreshnessPolicyDigest,
+  MAX_EVIDENCE_DEPENDENCIES,
+  type EvidenceFreshnessPolicy,
+} from './evidence-freshness.js';
+
+function digest(value: string): string {
+  return createHash('sha256').update(value).digest('hex');
+}
+
+function buildPolicy(size: number): EvidenceFreshnessPolicy {
+  return {
+    policyId: 'bench-read-set',
+    baseCommit: 'abc1234',
+    evaluatedAt: '2026-09-01T00:00:00.000Z',
+    // Reverse-ordered on purpose so the canonical sort actually does work.
+    dependencies: Array.from({ length: size }, (_, i) => ({
+      path: `packages/mod-${String(size - i).padStart(5, '0')}/src/index.ts`,
+      digest: digest(`content-${i}`),
+    })),
+    requireDeclaredDependencies: true,
+  };
+}
+
+function median(values: number[]): number {
+  const ordered = [...values].sort((a, b) => a - b);
+  return ordered[Math.floor(ordered.length / 2)]!;
+}
+
+describe('evidence freshness cost', () => {
+  it('verifies a full-size read set well inside a single frame', () => {
+    const policy = buildPolicy(MAX_EVIDENCE_DEPENDENCIES);
+    const expected = evidenceFreshnessPolicyDigest(policy);
+    const observed = {
+      headCommit: 'def5678',
+      observedAt: '2026-09-07T00:00:00.000Z',
+      dependencies: policy.dependencies.map((d, i) =>
+        i % 100 === 0 ? { ...d, digest: digest(`drifted-${i}`) } : d,
+      ),
+    };
+
+    for (let i = 0; i < 5; i++) evaluateEvidenceFreshness(policy, expected, observed);
+
+    const samples: number[] = [];
+    for (let i = 0; i < 20; i++) {
+      const start = performance.now();
+      const receipt = evaluateEvidenceFreshness(policy, expected, observed);
+      samples.push(performance.now() - start);
+      expect(receipt.status).toBe('STALE');
+    }
+
+    const p50 = median(samples);
+    // Generous: catches an accidental O(n^2), not a hardware-specific claim.
+    expect(p50).toBeLessThan(250);
+  });
+
+  it('scales sub-quadratically from 512 to 4096 dependencies', () => {
+    const measure = (size: number): number => {
+      const policy = buildPolicy(size);
+      const expected = evidenceFreshnessPolicyDigest(policy);
+      const observed = {
+        headCommit: 'def5678',
+        observedAt: '2026-09-07T00:00:00.000Z',
+        dependencies: policy.dependencies,
+      };
+      for (let i = 0; i < 3; i++) evaluateEvidenceFreshness(policy, expected, observed);
+      const samples: number[] = [];
+      for (let i = 0; i < 15; i++) {
+        const start = performance.now();
+        evaluateEvidenceFreshness(policy, expected, observed);
+        samples.push(performance.now() - start);
+      }
+      return median(samples);
+    };
+
+    const small = Math.max(measure(512), 0.01);
+    const large = measure(4_096);
+    // 8x the input; quadratic would be ~64x. Allow 24x for noise and hashing.
+    expect(large / small).toBeLessThan(24);
+  });
+});

--- a/packages/witness/src/evidence-freshness.test.ts
+++ b/packages/witness/src/evidence-freshness.test.ts
@@ -1,0 +1,277 @@
+import { createHash } from 'node:crypto';
+import { describe, expect, it } from 'vitest';
+import {
+  evaluateEvidenceFreshness,
+  evidenceFreshnessPolicyDigest,
+  MAX_EVIDENCE_DEPENDENCIES,
+  type EvidenceFreshnessObservation,
+  type EvidenceFreshnessPolicy,
+} from './evidence-freshness.js';
+
+function digest(value: string): string {
+  return createHash('sha256').update(value).digest('hex');
+}
+
+const POLICY: EvidenceFreshnessPolicy = {
+  policyId: 'dream-machine-pr-11',
+  baseCommit: '8ce3857',
+  evaluatedAt: '2026-08-15T09:16:50.000Z',
+  dependencies: [
+    { path: 'dream.config.json', digest: digest('autoMerge:true') },
+    { path: 'packages/compile/src/index.ts', digest: digest('compile-v1') },
+  ],
+  requireDeclaredDependencies: true,
+};
+
+function observation(overrides: Partial<EvidenceFreshnessObservation> = {}): EvidenceFreshnessObservation {
+  return {
+    headCommit: 'a2ea670',
+    observedAt: '2026-09-07T16:45:00.000Z',
+    dependencies: [
+      { path: 'dream.config.json', digest: digest('autoMerge:true') },
+      { path: 'packages/compile/src/index.ts', digest: digest('compile-v1') },
+    ],
+    ...overrides,
+  };
+}
+
+describe('evidence freshness', () => {
+  it('is FRESH when every declared dependency still has its evaluated content', () => {
+    const receipt = evaluateEvidenceFreshness(POLICY, evidenceFreshnessPolicyDigest(POLICY), observation());
+    expect(receipt.status).toBe('FRESH');
+    expect(receipt.authority).toBe('none');
+    expect(receipt.driftedPaths).toEqual([]);
+    expect(receipt.policyDigest).toMatch(/^[0-9a-f]{64}$/);
+    expect(receipt.observationDigest).toMatch(/^[0-9a-f]{64}$/);
+  });
+
+  // The regression this whole module exists for.
+  it('reproduces PR #11: a clean merge whose READ SET drifted is STALE', () => {
+    // dream.config.json was never in #11's diff -- git merged it without a
+    // conflict -- but the evaluation read it, and it changed underneath.
+    const drifted = observation({
+      dependencies: [
+        { path: 'dream.config.json', digest: digest('autoMerge:false') },
+        { path: 'packages/compile/src/index.ts', digest: digest('compile-v1') },
+      ],
+    });
+    const receipt = evaluateEvidenceFreshness(POLICY, evidenceFreshnessPolicyDigest(POLICY), drifted);
+    expect(receipt.status).toBe('STALE');
+    expect(receipt.driftedPaths).toEqual(['dream.config.json']);
+    expect(receipt.authority).toBe('none');
+  });
+
+  it('does NOT call a candidate stale merely because main moved', () => {
+    // The over-conservative gate this module deliberately is not: HEAD always
+    // differs from the evaluated base in a live repo.
+    const receipt = evaluateEvidenceFreshness(
+      POLICY,
+      evidenceFreshnessPolicyDigest(POLICY),
+      observation({ headCommit: 'ffffffe' }),
+    );
+    expect(receipt.baseCommitMoved).toBe(true);
+    expect(receipt.status).toBe('FRESH');
+  });
+
+  it('does NOT call an old candidate stale when its dependencies never moved', () => {
+    const receipt = evaluateEvidenceFreshness(
+      POLICY,
+      evidenceFreshnessPolicyDigest(POLICY),
+      observation({ observedAt: '2027-08-15T09:16:50.000Z' }),
+    );
+    expect(receipt.ageDays).toBeGreaterThan(300);
+    expect(receipt.ageExceeded).toBe(false);
+    expect(receipt.status).toBe('FRESH');
+  });
+
+  it('honours an explicit age bound as a secondary gate', () => {
+    const bounded: EvidenceFreshnessPolicy = { ...POLICY, maxAgeDays: 7 };
+    const receipt = evaluateEvidenceFreshness(
+      bounded,
+      evidenceFreshnessPolicyDigest(bounded),
+      observation(),
+    );
+    expect(receipt.ageDays).toBe(23);
+    expect(receipt.ageExceeded).toBe(true);
+    expect(receipt.status).toBe('STALE');
+  });
+
+  it('is INDETERMINATE, never FRESH, when a declared dependency was not observed', () => {
+    const receipt = evaluateEvidenceFreshness(
+      POLICY,
+      evidenceFreshnessPolicyDigest(POLICY),
+      observation({ dependencies: [{ path: 'dream.config.json', digest: digest('autoMerge:true') }] }),
+    );
+    expect(receipt.status).toBe('INDETERMINATE');
+    expect(receipt.missingPaths).toEqual(['packages/compile/src/index.ts']);
+  });
+
+  it('is INDETERMINATE when the observation carries paths the policy never declared', () => {
+    const receipt = evaluateEvidenceFreshness(
+      POLICY,
+      evidenceFreshnessPolicyDigest(POLICY),
+      observation({
+        dependencies: [
+          ...observation().dependencies,
+          { path: 'packages/ledger/src/index.ts', digest: digest('ledger') },
+        ],
+      }),
+    );
+    expect(receipt.status).toBe('INDETERMINATE');
+    expect(receipt.unexpectedPaths).toEqual(['packages/ledger/src/index.ts']);
+  });
+
+  it('reports drift ahead of age when both are present', () => {
+    const bounded: EvidenceFreshnessPolicy = { ...POLICY, maxAgeDays: 1 };
+    const receipt = evaluateEvidenceFreshness(
+      bounded,
+      evidenceFreshnessPolicyDigest(bounded),
+      observation({
+        dependencies: [
+          { path: 'dream.config.json', digest: digest('autoMerge:false') },
+          { path: 'packages/compile/src/index.ts', digest: digest('compile-v1') },
+        ],
+      }),
+    );
+    expect(receipt.status).toBe('STALE');
+    expect(receipt.driftedPaths).toEqual(['dream.config.json']);
+    expect(receipt.ageExceeded).toBe(true);
+  });
+
+  it('canonicalizes dependency ordering so the digest is order-independent', () => {
+    const reordered: EvidenceFreshnessPolicy = {
+      ...POLICY,
+      dependencies: [...POLICY.dependencies].reverse(),
+    };
+    expect(evidenceFreshnessPolicyDigest(reordered)).toBe(evidenceFreshnessPolicyDigest(POLICY));
+
+    const expected = evidenceFreshnessPolicyDigest(POLICY);
+    const forward = evaluateEvidenceFreshness(POLICY, expected, observation());
+    const backward = evaluateEvidenceFreshness(
+      POLICY,
+      expected,
+      observation({ dependencies: [...observation().dependencies].reverse() }),
+    );
+    expect(backward.observationDigest).toBe(forward.observationDigest);
+  });
+
+  describe('adversarial', () => {
+    it('invalidates a policy rewritten after the digest was anchored', () => {
+      // The attack this gate must survive: a stale candidate silently drops the
+      // dependency that drifted so nothing is left to detect.
+      const expected = evidenceFreshnessPolicyDigest(POLICY);
+      const rewritten: EvidenceFreshnessPolicy = {
+        ...POLICY,
+        dependencies: [{ path: 'packages/compile/src/index.ts', digest: digest('compile-v1') }],
+      };
+      const receipt = evaluateEvidenceFreshness(rewritten, expected, observation());
+      expect(receipt.status).toBe('INVALID');
+      expect(receipt.reason).toMatch(/policy digest mismatch/);
+    });
+
+    it('rejects an empty read set when dependencies are required', () => {
+      const empty: EvidenceFreshnessPolicy = { ...POLICY, dependencies: [] };
+      const receipt = evaluateEvidenceFreshness(empty, evidenceFreshnessPolicyDigest(empty), observation());
+      expect(receipt.status).toBe('INVALID');
+      expect(receipt.reason).toMatch(/declares no dependencies/);
+    });
+
+    it('rejects absolute paths and traversal in the read set', () => {
+      for (const path of ['/etc/shadow', '../../secrets.env', 'a/../../b', 'C:\\Windows\\x']) {
+        expect(() =>
+          evidenceFreshnessPolicyDigest({ ...POLICY, dependencies: [{ path, digest: digest('x') }] }),
+        ).toThrow();
+      }
+    });
+
+    it('rejects duplicate declared paths', () => {
+      expect(() =>
+        evidenceFreshnessPolicyDigest({
+          ...POLICY,
+          dependencies: [
+            { path: 'dream.config.json', digest: digest('a') },
+            { path: 'dream.config.json', digest: digest('b') },
+          ],
+        }),
+      ).toThrow(/duplicate path/);
+    });
+
+    it('rejects backdated observations', () => {
+      const receipt = evaluateEvidenceFreshness(
+        POLICY,
+        evidenceFreshnessPolicyDigest(POLICY),
+        observation({ observedAt: '2026-08-01T00:00:00.000Z' }),
+      );
+      expect(receipt.status).toBe('INVALID');
+      expect(receipt.reason).toMatch(/precedes evaluatedAt/);
+    });
+
+    it('rejects malformed digests, commits, timestamps and identifiers', () => {
+      expect(() =>
+        evidenceFreshnessPolicyDigest({ ...POLICY, policyId: '' }),
+      ).toThrow(/policyId/);
+      expect(() =>
+        evidenceFreshnessPolicyDigest({ ...POLICY, baseCommit: 'ZZZZ' }),
+      ).toThrow(/baseCommit/);
+      expect(() =>
+        evidenceFreshnessPolicyDigest({ ...POLICY, evaluatedAt: '2026-08-15' }),
+      ).toThrow(/evaluatedAt/);
+      expect(() =>
+        evidenceFreshnessPolicyDigest({
+          ...POLICY,
+          dependencies: [{ path: 'a.json', digest: 'NOTAHEXDIGEST' }],
+        }),
+      ).toThrow(/64 lowercase hex/);
+    });
+
+    it('rejects untrusted runtime values that bypass the TypeScript types', () => {
+      const bad = [
+        { ...POLICY, requireDeclaredDependencies: 'yes' as unknown as boolean },
+        { ...POLICY, dependencies: 'not-an-array' as unknown as EvidenceFreshnessPolicy['dependencies'] },
+        { ...POLICY, dependencies: [null] as unknown as EvidenceFreshnessPolicy['dependencies'] },
+        { ...POLICY, maxAgeDays: 0 },
+        { ...POLICY, maxAgeDays: -1 },
+        { ...POLICY, maxAgeDays: 1.5 },
+        { ...POLICY, maxAgeDays: Number.NaN },
+      ];
+      for (const policy of bad) {
+        expect(() => evidenceFreshnessPolicyDigest(policy as EvidenceFreshnessPolicy)).toThrow();
+      }
+    });
+
+    it('bounds the read set so a malformed policy cannot pin CPU', () => {
+      const huge = Array.from({ length: MAX_EVIDENCE_DEPENDENCIES + 1 }, (_, i) => ({
+        path: `packages/p${i}.ts`,
+        digest: digest(`d${i}`),
+      }));
+      expect(() => evidenceFreshnessPolicyDigest({ ...POLICY, dependencies: huge })).toThrow(
+        /exceeds 4096 entries/,
+      );
+    });
+
+    it('never throws out of evaluate, returning an INVALID receipt instead', () => {
+      const receipt = evaluateEvidenceFreshness(
+        POLICY,
+        evidenceFreshnessPolicyDigest(POLICY),
+        null as unknown as EvidenceFreshnessObservation,
+      );
+      expect(receipt.status).toBe('INVALID');
+      expect(receipt.authority).toBe('none');
+    });
+
+    it('holds no raw file content -- digests and paths only', () => {
+      const secret = 'SUPER_SECRET_TOKEN_VALUE';
+      const policy: EvidenceFreshnessPolicy = {
+        ...POLICY,
+        dependencies: [{ path: '.env.example', digest: digest(secret) }],
+      };
+      const receipt = evaluateEvidenceFreshness(policy, evidenceFreshnessPolicyDigest(policy), {
+        headCommit: 'a2ea670',
+        observedAt: '2026-09-07T16:45:00.000Z',
+        dependencies: [{ path: '.env.example', digest: digest('rotated') }],
+      });
+      expect(JSON.stringify(receipt)).not.toContain(secret);
+      expect(receipt.status).toBe('STALE');
+    });
+  });
+});

--- a/packages/witness/src/evidence-freshness.ts
+++ b/packages/witness/src/evidence-freshness.ts
@@ -1,0 +1,350 @@
+/**
+ * Evidence freshness: does a candidate's evaluation receipt still describe the
+ * tree it is about to be promoted into?
+ *
+ * Reproduced 2026-09-07 (backlog-landing night). PR #11 was evaluated on
+ * 2026-08-15 against `dream.config.json` as it stood that day, asserting
+ * `withDefaults(selfConfig).autoMerge === true` and golden-snapshotting the
+ * compiled prompt. Its own evaluation was honest and passed. Three weeks later
+ * the repository deliberately set `autoMerge: false`, and the compiled prompt
+ * legitimately evolved. When the PR finally landed, `main` went red on two
+ * tests — not because the diff was wrong, but because the *environment the
+ * evidence was collected in* had moved underneath it.
+ *
+ * The load-bearing detail is that **git merged #11 cleanly**. There was no
+ * conflict, because `dream.config.json` was never in #11's diff. It was in
+ * #11's *read set*: a file the evaluation depended on but did not modify.
+ *
+ *   git protects the WRITE set. Nothing here protected the READ set.
+ *
+ * Every gate in this repository freezes a policy *before* outcomes are visible
+ * (see `discovery-evidence.ts`, `claim-receipt.ts`) and then treats the
+ * resulting receipt as timeless. That is safe while a candidate lands the same
+ * night. It is not safe across a 30-PR, three-week backlog, which is exactly
+ * the regime this repository operates in.
+ *
+ * This module makes the read set an explicit, digest-anchored part of the
+ * evidence, and re-verifies it at promotion time.
+ *
+ * Deliberate non-goals, because getting these wrong makes the gate useless:
+ *
+ * - **A moved base commit is NOT staleness.** `main` advances constantly; a
+ *   gate that fires whenever HEAD != baseCommit fires always, gets ignored, and
+ *   protects nothing. `baseCommitMoved` is reported as context, never as a
+ *   stale verdict on its own.
+ * - **Age is NOT the primary signal.** A three-week-old candidate whose
+ *   dependencies never moved is still valid; a one-day-old candidate whose
+ *   dependencies moved is not. Age is an optional secondary bound for callers
+ *   who want one, not the mechanism.
+ * - **This module performs no I/O.** It never reads files, git, or the network.
+ *   The caller supplies observed digests, so the same pure function is usable
+ *   in CI, in a promotion gate, and in tests. Consistent with the rest of
+ *   `@dream-machine/witness`.
+ *
+ * Like every other receipt in this package, a FRESH verdict is evidence that
+ * the evaluation still applies. It is never authority to merge anything.
+ */
+
+import { createHash } from 'node:crypto';
+
+/** Upper bound on declared dependencies, so a malformed policy cannot pin CPU. */
+export const MAX_EVIDENCE_DEPENDENCIES = 4_096;
+/** Upper bound on a single repo-relative path, well past any real one. */
+export const MAX_EVIDENCE_PATH_LENGTH = 1_024;
+/** Upper bound on the optional age budget, in days. */
+export const MAX_EVIDENCE_AGE_DAYS = 3_650;
+
+export type FreshnessStatus = 'FRESH' | 'STALE' | 'INDETERMINATE' | 'INVALID';
+
+/**
+ * One member of the evidence's read set: a path the evaluation depended on,
+ * plus the digest of its content at the time the evidence was collected.
+ *
+ * Digests only. Raw file content never enters a receipt.
+ */
+export interface EvidenceDependency {
+  /** Repository-relative path. Never absolute, never traversing. */
+  path: string;
+  /** SHA-256 of the path's content when the evidence was produced. */
+  digest: string;
+}
+
+/** Frozen when the candidate is evaluated, before any promotion decision. */
+export interface EvidenceFreshnessPolicy {
+  /** Stable identity for this candidate's evidence. */
+  policyId: string;
+  /** The commit the evaluation actually ran against. */
+  baseCommit: string;
+  /** Canonical ISO 8601 timestamp of the evaluation. */
+  evaluatedAt: string;
+  /**
+   * The declared read set: every path whose content the evaluation's result
+   * depends on. This is deliberately broader than the diff -- config the tests
+   * load, fixtures they compare against, schemas they validate with.
+   */
+  dependencies: readonly EvidenceDependency[];
+  /**
+   * Reject an empty read set. An undeclared read set is not evidence that a
+   * candidate has no environmental dependencies; it is evidence that nobody
+   * looked. Default true, because the silent-empty case is precisely how this
+   * gate would get quietly defeated.
+   */
+  requireDeclaredDependencies: boolean;
+  /** Optional secondary bound. Omit for no age limit -- drift is the real gate. */
+  maxAgeDays?: number;
+}
+
+/** Taken at promotion time, against the tree the candidate would land in. */
+export interface EvidenceFreshnessObservation {
+  /** The commit the candidate would be promoted into. */
+  headCommit: string;
+  /** Canonical ISO 8601 timestamp of this observation. */
+  observedAt: string;
+  /** The same declared paths, digested against the current tree. */
+  dependencies: readonly EvidenceDependency[];
+}
+
+/** Deterministic freshness receipt. Carries evidence, never authority. */
+export interface EvidenceFreshnessReceipt {
+  status: FreshnessStatus;
+  authority: 'none';
+  policyDigest: string;
+  observationDigest: string;
+  /** Declared paths whose content changed since evaluation. The #11 signal. */
+  driftedPaths: string[];
+  /** Declared paths absent from the observation -- unverifiable, not fresh. */
+  missingPaths: string[];
+  /** Observed paths never declared -- the observation does not match the policy. */
+  unexpectedPaths: string[];
+  /** Whole days between evaluation and observation, or null if unmeasurable. */
+  ageDays: number | null;
+  /** True only when an explicit `maxAgeDays` was set and exceeded. */
+  ageExceeded: boolean;
+  /** Informational: HEAD differs from the evaluated base. Never stale on its own. */
+  baseCommitMoved: boolean;
+  reason?: string;
+}
+
+const HEX64 = /^[0-9a-f]{64}$/;
+const COMMIT_RE = /^[0-9a-f]{7,64}$/;
+const SAFE_ID = /^[A-Za-z0-9][A-Za-z0-9._:/@-]{0,255}$/;
+const MS_PER_DAY = 86_400_000;
+
+function sha256(value: string): string {
+  return createHash('sha256').update(value).digest('hex');
+}
+
+function requireId(value: string, field: string): string {
+  if (typeof value !== 'string') throw new Error(`${field} must be a string`);
+  const normalized = value.trim();
+  if (!SAFE_ID.test(normalized)) throw new Error(`${field} must be a nonempty bounded identifier`);
+  return normalized;
+}
+
+function requireDigest(value: string, field: string): string {
+  if (typeof value !== 'string' || !HEX64.test(value)) {
+    throw new Error(`${field} must be 64 lowercase hex characters`);
+  }
+  return value;
+}
+
+function requireCommit(value: string, field: string): string {
+  if (typeof value !== 'string' || !COMMIT_RE.test(value)) {
+    throw new Error(`${field} must be a lowercase hex commit sha`);
+  }
+  return value;
+}
+
+function requireCanonicalTimestamp(value: string, field: string): string {
+  if (typeof value !== 'string') throw new Error(`${field} must be a string`);
+  const parsed = new Date(value);
+  if (!Number.isFinite(parsed.getTime()) || parsed.toISOString() !== value) {
+    throw new Error(`${field} must be canonical ISO 8601 with milliseconds and Z`);
+  }
+  return value;
+}
+
+/**
+ * Repo-relative, non-traversing, bounded. A policy naming `/etc/shadow` or
+ * `../../secrets` is malformed, not merely unusual: the read set is a claim
+ * about this repository's tree, and anything outside it cannot be re-verified
+ * against a promotion target.
+ */
+function requirePath(value: string, field: string): string {
+  if (typeof value !== 'string') throw new Error(`${field} must be a string`);
+  const normalized = value.trim();
+  if (normalized.length === 0) throw new Error(`${field} must not be empty`);
+  if (normalized.length > MAX_EVIDENCE_PATH_LENGTH) {
+    throw new Error(`${field} exceeds ${MAX_EVIDENCE_PATH_LENGTH} characters`);
+  }
+  if (normalized.startsWith('/') || /^[A-Za-z]:[\\/]/.test(normalized)) {
+    throw new Error(`${field} must be repository-relative, not absolute`);
+  }
+  if (normalized.includes('\\')) throw new Error(`${field} must use forward slashes`);
+  if (normalized.split('/').some((segment) => segment === '..')) {
+    throw new Error(`${field} must not traverse outside the repository`);
+  }
+  if (normalized.includes('\0')) throw new Error(`${field} must not contain a null byte`);
+  return normalized;
+}
+
+/** Deterministic, duplicate-free, sorted read set. */
+function normalizedDependencies(
+  dependencies: readonly EvidenceDependency[],
+  field: string,
+): EvidenceDependency[] {
+  if (!Array.isArray(dependencies)) throw new Error(`${field} must be an array`);
+  if (dependencies.length > MAX_EVIDENCE_DEPENDENCIES) {
+    throw new Error(`${field} exceeds ${MAX_EVIDENCE_DEPENDENCIES} entries`);
+  }
+  const seen = new Set<string>();
+  const normalized = dependencies.map((dependency) => {
+    if (dependency === null || typeof dependency !== 'object') {
+      throw new Error(`${field} contains a non-object entry`);
+    }
+    const path = requirePath(dependency.path, `${field} path`);
+    if (seen.has(path)) throw new Error(`${field} contains duplicate path ${path}`);
+    seen.add(path);
+    return { path, digest: requireDigest(dependency.digest, `${field} digest for ${path}`) };
+  });
+  return normalized.sort((left, right) => (left.path < right.path ? -1 : left.path > right.path ? 1 : 0));
+}
+
+function normalizedMaxAgeDays(value: number | undefined, field: string): number | null {
+  if (value === undefined) return null;
+  if (!Number.isSafeInteger(value) || value < 1 || value > MAX_EVIDENCE_AGE_DAYS) {
+    throw new Error(`${field} must be an integer in [1, ${MAX_EVIDENCE_AGE_DAYS}]`);
+  }
+  return value;
+}
+
+/**
+ * Canonical digest of the freshness policy frozen at evaluation time.
+ *
+ * Anchoring this digest independently (in the PR body, the ledger row, a
+ * witness stamp) is what stops a stale candidate from simply rewriting its own
+ * read set at promotion time to make the drift disappear.
+ */
+export function evidenceFreshnessPolicyDigest(policy: EvidenceFreshnessPolicy): string {
+  if (policy === null || typeof policy !== 'object') throw new Error('policy must be an object');
+  if (typeof policy.requireDeclaredDependencies !== 'boolean') {
+    throw new Error('requireDeclaredDependencies must be boolean');
+  }
+  const canonical = JSON.stringify({
+    policyId: requireId(policy.policyId, 'policyId'),
+    baseCommit: requireCommit(policy.baseCommit, 'baseCommit'),
+    evaluatedAt: requireCanonicalTimestamp(policy.evaluatedAt, 'evaluatedAt'),
+    dependencies: normalizedDependencies(policy.dependencies, 'dependencies'),
+    requireDeclaredDependencies: policy.requireDeclaredDependencies,
+    maxAgeDays: normalizedMaxAgeDays(policy.maxAgeDays, 'maxAgeDays'),
+  });
+  return sha256(canonical);
+}
+
+function emptyReceipt(reason: string): EvidenceFreshnessReceipt {
+  return {
+    status: 'INVALID',
+    authority: 'none',
+    policyDigest: '',
+    observationDigest: '',
+    driftedPaths: [],
+    missingPaths: [],
+    unexpectedPaths: [],
+    ageDays: null,
+    ageExceeded: false,
+    baseCommitMoved: false,
+    reason,
+  };
+}
+
+/**
+ * Re-verify a frozen evidence policy against the tree it would be promoted
+ * into.
+ *
+ * A FRESH verdict means: every path the evaluation declared it depended on
+ * still has the exact content it had when the evidence was collected, so the
+ * evaluation's conclusion still describes this tree. It does not mean the
+ * change is correct, reviewed, or safe -- those are other gates' jobs -- and it
+ * never grants authority to merge.
+ */
+export function evaluateEvidenceFreshness(
+  policy: EvidenceFreshnessPolicy,
+  expectedPolicyDigest: string,
+  observation: EvidenceFreshnessObservation,
+): EvidenceFreshnessReceipt {
+  try {
+    const policyDigest = evidenceFreshnessPolicyDigest(policy);
+    requireDigest(expectedPolicyDigest, 'expectedPolicyDigest');
+    if (policyDigest !== expectedPolicyDigest) {
+      return emptyReceipt('policy digest mismatch');
+    }
+
+    if (observation === null || typeof observation !== 'object') {
+      throw new Error('observation must be an object');
+    }
+
+    const declared = normalizedDependencies(policy.dependencies, 'dependencies');
+    if (policy.requireDeclaredDependencies && declared.length === 0) {
+      return emptyReceipt('policy declares no dependencies while requireDeclaredDependencies is set');
+    }
+
+    const headCommit = requireCommit(observation.headCommit, 'headCommit');
+    const observedAt = requireCanonicalTimestamp(observation.observedAt, 'observedAt');
+    const observed = normalizedDependencies(observation.dependencies, 'observed dependencies');
+
+    const evaluatedMs = Date.parse(policy.evaluatedAt);
+    const observedMs = Date.parse(observedAt);
+    if (observedMs < evaluatedMs) {
+      return emptyReceipt('observedAt precedes evaluatedAt');
+    }
+    const ageDays = Math.floor((observedMs - evaluatedMs) / MS_PER_DAY);
+
+    const observedByPath = new Map(observed.map((dependency) => [dependency.path, dependency.digest]));
+    const declaredPaths = new Set(declared.map((dependency) => dependency.path));
+
+    const driftedPaths: string[] = [];
+    const missingPaths: string[] = [];
+    for (const dependency of declared) {
+      const current = observedByPath.get(dependency.path);
+      if (current === undefined) missingPaths.push(dependency.path);
+      else if (current !== dependency.digest) driftedPaths.push(dependency.path);
+    }
+    const unexpectedPaths = observed
+      .map((dependency) => dependency.path)
+      .filter((path) => !declaredPaths.has(path));
+
+    const maxAgeDays = normalizedMaxAgeDays(policy.maxAgeDays, 'maxAgeDays');
+    const ageExceeded = maxAgeDays !== null && ageDays > maxAgeDays;
+
+    // A moved base commit is the normal case, never a stale verdict by itself.
+    const baseCommitMoved = headCommit !== requireCommit(policy.baseCommit, 'baseCommit');
+
+    const observationDigest = sha256(JSON.stringify({ headCommit, observedAt, dependencies: observed }));
+
+    let status: FreshnessStatus;
+    if (driftedPaths.length > 0 || ageExceeded) {
+      status = 'STALE';
+    } else if (missingPaths.length > 0 || unexpectedPaths.length > 0) {
+      // Cannot verify what was not observed, and an observation carrying paths
+      // the policy never declared is not the observation this policy describes.
+      status = 'INDETERMINATE';
+    } else {
+      status = 'FRESH';
+    }
+
+    return {
+      status,
+      authority: 'none',
+      policyDigest,
+      observationDigest,
+      driftedPaths,
+      missingPaths,
+      unexpectedPaths,
+      ageDays,
+      ageExceeded,
+      baseCommitMoved,
+    };
+  } catch (error) {
+    return emptyReceipt(error instanceof Error ? error.message : 'invalid evidence freshness input');
+  }
+}

--- a/packages/witness/src/index.ts
+++ b/packages/witness/src/index.ts
@@ -123,6 +123,7 @@ export function verifySteps(gistRawUrl = '<RAW_GIST_URL>'): string {
 export * from './security-patch.js';
 export * from './reconstruction.js';
 export * from './termination.js';
+export * from './evidence-freshness.js';
 // `trace-replay` and `termination` were developed on separate branches and each
 // grew its own `canonicalJson`, so `export *` from both is ambiguous (TS2308).
 // They are NOT interchangeable -- trace-replay's carries WeakSet cycle detection


### PR DESCRIPTION
## 1. Hypothesis

> Given a candidate whose evaluation receipt was produced against an earlier tree, when the paths that evaluation *read* are digest-anchored at evaluation time and re-digested against the promotion target, then drift in that read set should be detected even when git reports no conflict — subject to: (1) a moved base commit alone never yields STALE; (2) age alone is not the mechanism; (3) the witness primitive performs no I/O; (4) no receipt carries file content.

## 2. The failure this is derived from

**PR #11 merged cleanly and still broke `main`.** It was evaluated 2026-08-15 asserting `withDefaults(selfConfig).autoMerge === true` plus a golden prompt snapshot. Honest evaluation, passed. Three weeks later the repo deliberately set `autoMerge: false`; on landing, two tests went red (repaired in #95).

`dream.config.json` **was never in #11's diff** — git had nothing to conflict on. It was in #11's *read set*.

> git protects the WRITE set. Nothing here protected the READ set.

This is not "receipts get old." A three-week-old candidate whose dependencies never moved is still valid; a one-day-old candidate whose dependencies moved is not. Age is the wrong axis.

## 3. Candidate

`EvidenceFreshnessPolicy` / `EvidenceFreshnessReceipt` in `@dream-machine/witness`, plus `dream-machine freshness stamp|verify`.

The policy freezes: policy id, base commit, evaluation timestamp, the **declared read set** (path + SHA-256 at eval time), `requireDeclaredDependencies`, optional `maxAgeDays`. At promotion the same paths are re-digested and compared.

`FRESH` / `STALE` / `INDETERMINATE` (unverifiable is never fresh) / `INVALID`. Every receipt carries `authority: 'none'` per ADR-0007/0009 — evidence that an evaluation still applies, never permission to merge.

**Deliberate non-goals**, because getting them wrong makes the gate useless:
- a moved base commit is *not* staleness — `main` advances constantly; that gate fires always and gets switched off
- age is a secondary bound, not the mechanism
- the primitive does no I/O; the CLI supplies observed digests

## 4. Evaluation Receipt

Vitest, deterministic, $0, zero LLM calls. **616/616**, typecheck clean.

- 19 unit tests incl. the #11 regression and an adversarial block (policy rewriting, path traversal, duplicates, backdated observations, runtime type bypass, resource bounds, no-content-in-receipt)
- 11 CLI tests incl. exit-code contract (0/1/2)
- 2 cost tests: sub-quadratic 512→4096 deps

**Validated against real history, not fixtures:** stamping `dream.config.json` from `8ce3857` (#11's actual evaluation base) and verifying against current `main` returns `STALE`, `driftedPaths: ["dream.config.json"]`, exit 1.

## 5. Security Review

Adversarial review of this change found a real defect **in this change**: `freshness verify` originally digested every declared path *before* the library validated them, so an untrusted policy file naming `../../etc/hosts` would be read — and its existence confirmed — before coming back INVALID. A read/existence oracle.

Fixed by validating and anchoring the policy before any filesystem access, with two regression tests (one asserts the *only* path read is the policy file itself). Also: digests only, never content (tested); bounded read set, path length, and age; no ReDoS-prone patterns; absolute paths, `..` traversal, backslashes and null bytes rejected.

## 6. Reward Hack Check

No test weakened. One pre-existing assertion in my own earlier commit was *strengthened* (a rewritten policy now produces no receipt at all rather than an INVALID one emitted after touching the filesystem) — called out explicitly in the diff. Full suite reported both ways; the single local `npm run check` failure is the macOS-only `/tmp`→`/private/tmp` symlink case in `mission.test.mjs`, not exercised by this repo's Linux CI.

## 7. What this does and does not do

It supplies the missing freshness input a bounded auto-landing path would need before acting on a three-week-old ACCEPT verdict. It does not close the promotion loop by itself, and a read set declared too narrowly will still miss drift — this raises the floor, it does not prove independence.

## 8. ADR

ADR-0010 (Proposed), indexed.

## 9. Merge Policy

Human review required. Evaluation is not promotion.

🤖 Generated with [RuFlo](https://github.com/ruvnet/ruflo)

https://claude.ai/code/session_01Ff2xRKvYrqXJhefvcapfE1